### PR TITLE
fix: jupyter labextension develop . --overwrite not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,15 @@ node_modules/
 .ipynb_checkpoints
 *.iml
 .idea/
+*.tsbuildinfo
+.DS_Store
+*.lock
+__pycache__
+
+# Ensure embedme does not run ont node_modules README.md files.
+**/node_modules/**/README.md
+
+static
+labextension
+**/test-results/
+

--- a/globus_jupyterlab/__init__.py
+++ b/globus_jupyterlab/__init__.py
@@ -1,0 +1,16 @@
+
+import json
+import os.path as osp
+
+from ._version import __version__
+
+HERE = osp.abspath(osp.dirname(__file__))
+
+with open(osp.join(HERE, 'labextension', 'package.json')) as fid:
+    data = json.load(fid)
+
+def _jupyter_labextension_paths():
+    return [{
+        'src': 'labextension',
+        'dest': data['name']
+    }]

--- a/globus_jupyterlab/_version.py
+++ b/globus_jupyterlab/_version.py
@@ -1,0 +1,18 @@
+import json
+from pathlib import Path
+
+__all__ = ["__version__"]
+
+def _fetchVersion():
+    HERE = Path(__file__).parent.resolve()
+
+    for settings in HERE.rglob("package.json"): 
+        try:
+            with settings.open() as f:
+                return json.load(f)["version"]
+        except FileNotFoundError:
+            pass
+
+    raise FileNotFoundError(f"Could not find package.json under dir {HERE!s}")
+
+__version__ = _fetchVersion()

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "style/*.css",
         "style/index.js"
     ],
-    "styleModule": "style/index.js",
+    "style": "style/index.css",
     "publishConfig": {
         "access": "public"
     },

--- a/style/index.js
+++ b/style/index.js
@@ -1,1 +1,0 @@
-import './index.css';


### PR DESCRIPTION
The command above started failing for me recently with a strange
vague error:

ModuleNotFoundError: There is no labextension at .. Errors encountered: [TypeError("the 'package' argument is required to perform a relative import for '.'")]

Generally, globus_jupyterlab/ seemed like it would autogenerate most
times just fine without any intervention. However, in this case it wasn't
for me, and the `jupyter labextension develop` command searches under the
package name + __init__.py to discover whether the following item exists:

_jupyter_labextension_paths

And uses that to determine whether the folder you're trying to install is
a "real" labextension package, otherwise it fails with the vague error
above.

Adding those items should fix this from happening again