### PR TITLE
feat: Add basic server extension handler api

### DIFF
--- a/globus_jupyterlab/__init__.py
+++ b/globus_jupyterlab/__init__.py
@@ -1,16 +1,35 @@
-
 import json
-import os.path as osp
+from pathlib import Path
 
+from .handlers import setup_handlers
 from ._version import __version__
 
-HERE = osp.abspath(osp.dirname(__file__))
+HERE = Path(__file__).parent.resolve()
 
-with open(osp.join(HERE, 'labextension', 'package.json')) as fid:
+with (HERE / "labextension" / "package.json").open() as fid:
     data = json.load(fid)
 
+
 def _jupyter_labextension_paths():
-    return [{
-        'src': 'labextension',
-        'dest': data['name']
-    }]
+    return [{"src": "labextension", "dest": data["name"]}]
+
+
+def _jupyter_server_extension_points():
+    return [{"module": "globus_jupyterlab"}]
+
+
+def _load_jupyter_server_extension(server_app):
+    """Registers the API handler to receive HTTP requests from the frontend extension.
+    Parameters
+    ----------
+    server_app: jupyterlab.labapp.LabApp
+        JupyterLab application instance
+    """
+    url_path = "globus-jupyterlab"
+    setup_handlers(server_app.web_app, url_path)
+    server_app.log.info(
+        f"Registered jlab_ext_example extension at URL path /{url_path}"
+    )
+
+# For backward compatibility with the classical notebook
+load_jupyter_server_extension = _load_jupyter_server_extension

--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -1,0 +1,43 @@
+import os
+import logging
+import pickle
+import base64
+
+import globus_sdk
+
+log = logging.getLogger(__name__)
+
+
+class GlobusConfig():
+
+    def get_hub_token(self) -> str:
+        return os.getenv('JUPYTERHUB_API_TOKEN', '')
+
+    def is_gcp(self) -> str:
+        return bool(self.get_gcp_collection())
+
+    def get_gcp_collection(self) -> str:
+        return globus_sdk.LocalGlobusConnectPersonal().endpoint_id
+
+    def get_collection_id_owner(self) -> str:
+        return globus_sdk.LocalGlobusConnectPersonal().get_owner_info().id
+
+    def get_local_globus_collection(self) -> str:
+        return (
+            self.get_gcp_collection() or
+            self.get_oauthenticator_data().get('endpoint_id') or
+            None
+        )
+
+    def get_collection_base_path(self) -> str:
+        return os.getcwd()
+
+    def get_oauthenticator_data(self) -> dict:
+            # Fetch any info set by the Globus Juptyterhub OAuthenticator
+        oauthonticator_env = os.getenv('GLOBUS_DATA')
+        if oauthonticator_env:
+            try:
+                return pickle.loads(base64.b64decode(oauthonticator_env))
+            except pickle.UnpicklingError:
+                log.error('Failed to load GLOBUS_DATA', exc_info=True)
+                return dict()

--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -9,6 +9,12 @@ log = logging.getLogger(__name__)
 
 
 class GlobusConfig():
+    """
+    Track all Globus Related information related to the Globus Jupyterlab
+    server extension. This includes things like checking for a local
+    Globus Connect Personal on a user's machine, or fetching the hub
+    api token if it is available.
+    """
 
     def get_hub_token(self) -> str:
         return os.getenv('JUPYTERHUB_API_TOKEN', '')

--- a/globus_jupyterlab/handlers/__init__.py
+++ b/globus_jupyterlab/handlers/__init__.py
@@ -3,8 +3,6 @@ import logging
 from types import ModuleType
 from typing import List, Tuple
 
-logging.basicConfig(level=logging.DEBUG)
-
 from notebook.utils import url_path_join
 from notebook.base.handlers import APIHandler
 from jupyter_server.serverapp import ServerWebApplication

--- a/globus_jupyterlab/handlers/__init__.py
+++ b/globus_jupyterlab/handlers/__init__.py
@@ -1,0 +1,28 @@
+import os
+
+from notebook.utils import url_path_join
+
+from tornado.web import StaticFileHandler
+from globus_jupyterlab.handlers import login, config
+
+
+def setup_handlers(web_app, url_path):
+    host_pattern = ".*$"
+    base_url = web_app.settings["base_url"]
+    handlers = (login, config)
+
+    # Prepend the base_url so that it works in a JupyterHub setting
+    for handler_module in handlers:
+        for url, api_handler in handler_module.default_handlers:
+            handlers.append((url_path_join(base_url, url_path, url), api_handler))
+
+    web_app.add_handlers(host_pattern, handlers)
+
+    # Prepend the base_url so that it works in a JupyterHub setting
+    doc_url = url_path_join(base_url, url_path, "public")
+    doc_dir = os.getenv(
+        "JLAB_SERVER_EXAMPLE_STATIC_DIR",
+        os.path.join(os.path.dirname(__file__), "public"),
+    )
+    handlers = [("{}/(.*)".format(doc_url), StaticFileHandler, {"path": doc_dir})]
+    web_app.add_handlers(".*$", handlers)

--- a/globus_jupyterlab/handlers/__init__.py
+++ b/globus_jupyterlab/handlers/__init__.py
@@ -1,10 +1,13 @@
 import os
 import logging
+from types import ModuleType
+from typing import List, Tuple
 
 logging.basicConfig(level=logging.DEBUG)
 
 from notebook.utils import url_path_join
-
+from notebook.base.handlers import APIHandler
+from jupyter_server.serverapp import ServerWebApplication
 from tornado.web import StaticFileHandler
 from globus_jupyterlab.handlers import login, config
 
@@ -14,7 +17,16 @@ log = logging.getLogger(__name__)
 HANDLER_MODULES = (login, config)
 
 
-def get_handlers(modules, base_url, url_path) -> list:
+def get_handlers(modules: List[ModuleType], base_url: str, url_path: str) -> List[Tuple[str, APIHandler]]:
+    """
+    Fetch handlers from a list of modules. This style is taken from Jupyterhub,
+    which declares `default_handlers` on each of its handler modules and adds
+    them to a list here:
+    https://github.com/jupyterhub/jupyterhub/blob/main/jupyterhub/handlers/login.py#L168
+    Given a list of handler modules, this function will append the base_url and
+    url_path to each handler endpoint, which can then be passed straight to a
+    ServerWebApplication
+    """
     handlers = []
     for module in modules:
         for url, api_handler in module.default_handlers:
@@ -24,7 +36,11 @@ def get_handlers(modules, base_url, url_path) -> list:
     return handlers
 
 
-def setup_handlers(web_app, url_path):
+def setup_handlers(web_app: ServerWebApplication, url_path: str):
+    """
+    Setup main webapp handlers. Automatically adds all handlers
+    defined in HANDLER_MODULES.
+    """
     host_pattern = ".*$"
     base_url = web_app.settings["base_url"]
 

--- a/globus_jupyterlab/handlers/base.py
+++ b/globus_jupyterlab/handlers/base.py
@@ -1,0 +1,15 @@
+from notebook.base.handlers import APIHandler
+
+
+class RedirectWebHandler(APIHandler):
+    """Redirect Web Handlers are intended for redirecting outside of the Jupyterlab
+    app. This can be used for both the OAuth web flow, or alternativly helper pages."""
+
+    def set_default_headers(self, *args, **kwargs):
+        """This is needed for redirect back to JupyterLab from an outside source.
+        Typically, this is shady and will cause a security warning from Jupyter Server, but
+        for intentional usage we need to tell Jupyterlab to ignore the source from a third
+        party server."""
+        # We should look into this to see if we can get more specific, such as by setting
+        # auth.globus.org, or app.globus.org. 
+        self.set_header("Content-Security-Policy", "*")

--- a/globus_jupyterlab/handlers/base.py
+++ b/globus_jupyterlab/handlers/base.py
@@ -1,7 +1,13 @@
 from notebook.base.handlers import APIHandler
+from globus_jupyterlab.globus_config import GlobusConfig
 
 
-class RedirectWebHandler(APIHandler):
+class BaseAPIHandler(APIHandler):
+    gconfig = GlobusConfig()
+
+
+
+class RedirectWebHandler(BaseAPIHandler):
     """Redirect Web Handlers are intended for redirecting outside of the Jupyterlab
     app. This can be used for both the OAuth web flow, or alternativly helper pages."""
 

--- a/globus_jupyterlab/handlers/config.py
+++ b/globus_jupyterlab/handlers/config.py
@@ -1,58 +1,24 @@
 import json
-import os
-import base64
-import pickle
 import tornado
-import globus_sdk
-
-from notebook.base.handlers import APIHandler
+from globus_jupyterlab.handlers.base import BaseAPIHandler
 
 
-class Config(APIHandler):
+class Config(BaseAPIHandler):
     """API Endpoint for fetching information about how the Juptyerlab Backend is configured.
     Configuration can be customized through the hub, such as by setting the Globus Collection
     where the hub prefers its transfers, or alternatively by the user's local installation if
     they have GCP installed."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Fetch any local Globus SDK info
-        self.local_gcp = globus_sdk.LocalGlobusConnectPersonal()
-        self.log.info(f'Local GCP Endpoint: {self.local_gcp.endpoint_id}')
-
-        # Fetch any info set by the Globus Juptyterhub OAuthenticator
-        oauthonticator_env = os.getenv('GLOBUS_DATA')
-        if oauthonticator_env:
-            try:
-                self.oauthenticator_data = pickle.loads(base64.b64decode(oauthonticator_env))
-            except pickle.UnpicklingError:
-                self.log.error('Failed to load GLOBUS_DATA', exc_info=True)
-                self.oauthenticator_data = dict()
-        else:
-            self.oauthenticator_data = dict()
-        self.log.info(f'Jupyterhub OAuthenticator data present? {bool(self.oauthenticator_data)}')
-
     @tornado.web.authenticated
     def get(self, *args, **kwargs):
-        """
-        Accept a redirect from Globus Auth, and process the 'auth_code' in the query params.
-        """
+        
         data = {
-            'collection_id': self.get_local_globus_collection(),
-            # CWD *should* always map to the location where Juptyerlab has been started.
-            # Special note, this may not map perfectly to the share locations GCP allows.
-            'collection_base_path': os.getcwd(),
-            'is_gcp': bool(globus_sdk.LocalGlobusConnectPersonal().endpoint_id),
-            'collection_id_owner': self.local_gcp.get_owner_info().id,
+            'collection_id': self.gconfig.get_local_globus_collection(),
+            'collection_base_path': self.gconfig.get_collection_base_path(),
+            'is_gcp': self.gconfig.is_gcp(),
+            'collection_id_owner': self.gconfig.get_collection_id_owner(),
         }
-        self.log.debug(data)
         self.finish(json.dumps(data))
 
-    def get_local_globus_collection(self) -> str:
-        return (
-            self.local_gcp.endpoint_id or
-            self.oauthenticator_data.get('endpoint_id') or
-            None
-        )
 
 default_handlers = [('/config', Config)]

--- a/globus_jupyterlab/handlers/config.py
+++ b/globus_jupyterlab/handlers/config.py
@@ -1,0 +1,47 @@
+import json
+import os
+import base64
+import pickle
+import tornado
+import globus_sdk
+
+
+from notebook.base.handlers import APIHandler
+
+
+class Config(APIHandler):
+    """API Endpoint for fetching information about how the Juptyerlab Backend is configured.
+    Configuration can be customized through the hub, such as by setting the Globus Collection
+    where the hub prefers its transfers, or alternatively by the user's local installation if
+    they have GCP installed."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Fetch any local Globus SDK info
+        self.local_gcp = globus_sdk.LocalGlobusConnectPersonal()
+
+        # Fetch any info set by the Globus Juptyterhub OAuthenticator
+        oauthonticator_env = os.getenv('GLOBUS_DATA')
+        if oauthonticator_env:
+            self.oauthenticator_data = pickle.loads(base64.b64decode(oauthonticator_env))
+        else:
+            self.oauthenticator_data = dict()
+
+    @tornado.web.authenticated
+    def get(self, *args, **kwargs):
+        """
+        Accept a redirect from Globus Auth, and process the 'auth_code' in the query params.
+        """
+        data = {
+            'collection_id': self.get_local_globus_collection()
+        }
+        self.finish(json.dumps(data))
+
+    def get_local_globus_collection(self) -> str:
+        return (
+            self.local_gcp.endpoint_id or
+            self.oauthenticator_data.get('endpoint_id') or
+            None
+        )
+
+default_handlers = [('/config', Config)]

--- a/globus_jupyterlab/handlers/config.py
+++ b/globus_jupyterlab/handlers/config.py
@@ -5,7 +5,6 @@ import pickle
 import tornado
 import globus_sdk
 
-
 from notebook.base.handlers import APIHandler
 
 
@@ -19,13 +18,19 @@ class Config(APIHandler):
         super().__init__(*args, **kwargs)
         # Fetch any local Globus SDK info
         self.local_gcp = globus_sdk.LocalGlobusConnectPersonal()
+        self.log.info(f'Local GCP Endpoint: {self.local_gcp.endpoint_id}')
 
         # Fetch any info set by the Globus Juptyterhub OAuthenticator
         oauthonticator_env = os.getenv('GLOBUS_DATA')
         if oauthonticator_env:
-            self.oauthenticator_data = pickle.loads(base64.b64decode(oauthonticator_env))
+            try:
+                self.oauthenticator_data = pickle.loads(base64.b64decode(oauthonticator_env))
+            except pickle.UnpicklingError:
+                self.log.error('Failed to load GLOBUS_DATA', exc_info=True)
+                self.oauthenticator_data = dict()
         else:
             self.oauthenticator_data = dict()
+        self.log.info(f'Jupyterhub OAuthenticator data present? {bool(self.oauthenticator_data)}')
 
     @tornado.web.authenticated
     def get(self, *args, **kwargs):
@@ -33,8 +38,14 @@ class Config(APIHandler):
         Accept a redirect from Globus Auth, and process the 'auth_code' in the query params.
         """
         data = {
-            'collection_id': self.get_local_globus_collection()
+            'collection_id': self.get_local_globus_collection(),
+            # CWD *should* always map to the location where Juptyerlab has been started.
+            # Special note, this may not map perfectly to the share locations GCP allows.
+            'collection_base_path': os.getcwd(),
+            'is_gcp': bool(globus_sdk.LocalGlobusConnectPersonal().endpoint_id),
+            'collection_id_owner': self.local_gcp.get_owner_info().id,
         }
+        self.log.debug(data)
         self.finish(json.dumps(data))
 
     def get_local_globus_collection(self) -> str:

--- a/globus_jupyterlab/handlers/login.py
+++ b/globus_jupyterlab/handlers/login.py
@@ -1,0 +1,41 @@
+import tornado
+
+from notebook.base.handlers import APIHandler
+from globus_jupyterlab.handlers.base import RedirectWebHandler
+
+
+class Login(APIHandler):
+
+    @tornado.web.authenticated
+    def get(self, *args, **kwargs):
+        """
+        Redirect to Globus Auth for the first 'authorization' hop.
+        """
+        # self.finish()
+        pass
+
+
+class Logout(APIHandler):
+
+    @tornado.web.authenticated
+    def get(self, *args, **kwargs):
+        """
+        Revoke all local Gloubs tokens
+        """
+        pass
+
+
+class AuthCallback(RedirectWebHandler):
+
+    @tornado.web.authenticated
+    def get(self, *args, **kwargs):
+        """
+        Accept a redirect from Globus Auth, and process the 'auth_code' in the query params.
+        """
+        # self.finish()
+        pass
+
+
+default_handlers = [('/login', Login),
+                    ('/logout', Logout),
+                    ('/oauth_callback', AuthCallback)]

--- a/globus_jupyterlab/handlers/login.py
+++ b/globus_jupyterlab/handlers/login.py
@@ -1,10 +1,9 @@
 import tornado
 
-from notebook.base.handlers import APIHandler
-from globus_jupyterlab.handlers.base import RedirectWebHandler
+from globus_jupyterlab.handlers.base import BaseAPIHandler, RedirectWebHandler
 
 
-class Login(APIHandler):
+class Login(BaseAPIHandler):
 
     @tornado.web.authenticated
     def get(self, *args, **kwargs):
@@ -15,7 +14,7 @@ class Login(APIHandler):
         pass
 
 
-class Logout(APIHandler):
+class AuthCallback(RedirectWebHandler):
 
     @tornado.web.authenticated
     def get(self, *args, **kwargs):
@@ -25,7 +24,7 @@ class Logout(APIHandler):
         pass
 
 
-class AuthCallback(RedirectWebHandler):
+class Logout(BaseAPIHandler):
 
     @tornado.web.authenticated
     def get(self, *args, **kwargs):

--- a/globus_jupyterlab/jupyter-config/nb-config/globus_jupyterlab.json
+++ b/globus_jupyterlab/jupyter-config/nb-config/globus_jupyterlab.json
@@ -1,0 +1,8 @@
+{
+    "NotebookApp": {
+      "nbserver_extensions": {
+        "globus_jupyterlab": true
+      }
+    }
+  }
+  

--- a/globus_jupyterlab/jupyter-config/server-config/globus_jupyterlab.json
+++ b/globus_jupyterlab/jupyter-config/server-config/globus_jupyterlab.json
@@ -1,0 +1,8 @@
+{
+    "NotebookApp": {
+      "nbserver_extensions": {
+        "globus_jupyterlab": true
+      }
+    }
+  }
+  

--- a/globus_jupyterlab/tests/__init__.py
+++ b/globus_jupyterlab/tests/__init__.py
@@ -1,0 +1,22 @@
+import logging.config
+
+logging.config.dictConfig({
+    'version': 1,
+    'formatters': {
+        'basic': {'format': '[%(levelname)s] '
+                            '%(name)s::%(funcName)s() %(message)s'}
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'level': 'DEBUG',
+            'formatter': 'basic',
+        }
+    },
+    'loggers': {
+        'globus_jupyterlab': {'level': 'DEBUG', 'handlers': ['console']},
+        'tornado.access': {'level': 'WARNING', 'handlers': ['console']},
+        'tornado.application': {'level': 'DEBUG', 'handlers': ['console']},
+        'tornado.general': {'level': 'WARNING', 'handlers': ['console']},
+    },
+})

--- a/globus_jupyterlab/tests/conftest.py
+++ b/globus_jupyterlab/tests/conftest.py
@@ -1,0 +1,35 @@
+
+from unittest import mock
+import pytest
+import os
+from unittest.mock import Mock
+import globus_sdk
+import base64
+import pickle
+import tornado.web
+
+
+from globus_jupyterlab.handlers import get_handlers, HANDLER_MODULES
+
+application = tornado.web.Application(get_handlers(HANDLER_MODULES, '/', ''))
+
+
+@pytest.fixture
+def app():
+    return application
+
+
+@pytest.fixture
+def mock_gcp(monkeypatch) -> Mock:
+    gcp = Mock()
+    # Set instance vars to return some mock values
+    monkeypatch.setattr(globus_sdk, 'LocalGlobusConnectPersonal', Mock())
+    return globus_sdk.LocalGlobusConnectPersonal.return_value
+
+
+@pytest.fixture
+def mock_oauthenticator(monkeypatch) -> Mock:
+    data = {'client_id': 'client_uuid', 'tokens': dict()}
+    encoded_data = base64.b64encode(pickle.dumps(data))
+    monkeypatch.setenv('GLOBUS_DATA', str(encoded_data))
+    return data

--- a/globus_jupyterlab/tests/test_config_handler.py
+++ b/globus_jupyterlab/tests/test_config_handler.py
@@ -1,0 +1,25 @@
+import json
+import pytest
+
+
+@pytest.mark.gen_test
+def test_config_with_gcp_environment(http_client, base_url, mock_gcp):
+    mock_gcp.endpoint_id = 'my_gcp_id'
+    mock_gcp.get_owner_info.return_value.id = 'owner_uuid'
+    response = yield http_client.fetch(base_url + '/config')
+    assert response.code == 200
+    data = json.loads(response.body)
+    assert data['collection_id'] == 'my_gcp_id'
+    assert data['collection_id_owner'] == 'owner_uuid'
+    assert data['is_gcp'] is True
+
+
+@pytest.mark.gen_test
+def test_config_with_hub_environment(http_client, base_url, mock_gcp, mock_oauthenticator):
+    mock_gcp.endpoint_id = None
+    mock_gcp.get_owner_info.return_value.id = None
+
+    response = yield http_client.fetch(base_url + '/config')
+    data = json.loads(response.body)
+    assert response.code == 200
+    assert data['is_gcp'] is False

--- a/globus_jupyterlab/tests/test_globus_config.py
+++ b/globus_jupyterlab/tests/test_globus_config.py
@@ -1,0 +1,6 @@
+from globus_jupyterlab.globus_config import GlobusConfig
+
+
+def test_get_hub_token(monkeypatch):
+    monkeypatch.setenv('JUPYTERHUB_API_TOKEN', 'i_am_a_token!')
+    assert GlobusConfig().get_hub_token() == 'i_am_a_token!'

--- a/globus_jupyterlab/tests/test_setup.py
+++ b/globus_jupyterlab/tests/test_setup.py
@@ -1,0 +1,21 @@
+
+from unittest.mock import Mock
+from globus_jupyterlab.handlers import setup_handlers, get_handlers
+
+
+def test_get_handlers():
+    mock_handler = Mock()
+    handlers = [
+        ('my_handler_path', mock_handler)
+    ]
+    mock_module = Mock()
+    mock_module.default_handlers = handlers
+    processed_handlers = get_handlers([mock_module], '/base', 'path')
+
+    assert processed_handlers == [('/base/path/my_handler_path', mock_handler)]
+
+
+def test_setup_handlers():
+    mock_app = Mock(settings=dict(base_url='/base'))
+    setup_handlers(mock_app, '/mount')
+    assert mock_app.add_handlers.called

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "@jupyterlab/application": "^3.2.3",
         "@jupyterlab/apputils": "^3.2.3",
         "@jupyterlab/filebrowser": "^3.2.3",
+        "@jupyterlab/launcher": "^3.2.9",
         "@lumino/coreutils": "^1.11.1",
         "@lumino/widgets": "^1.30.0",
         "@types/crypto-js": "^4.0.2",
@@ -84,6 +85,16 @@
         "access": "public"
     },
     "jupyterlab": {
+        "discovery": {
+            "server": {
+                "managers": [
+                    "pip"
+                ],
+                "base": {
+                    "name": "globus_jupyterlab"
+                }
+            }
+        },
         "extension": true,
         "outputDir": "globus_jupyterlab/labextension"
     },

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,11 @@ version = (
     .replace("-rc.", "rc")
 )
 
+requirements = [
+        "jupyter_server>=1.6,<2",
+        "globus_sdk>=3>4",
+]
+
 setup_args = dict(
     name=name,
     version=version,
@@ -55,8 +60,10 @@ setup_args = dict(
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),
-    install_requires=[
-        "jupyter_server>=1.6,<2"
+    install_requires=requirements,
+    tests_require=requirements + [
+        'pytest',
+        'pytest-tornado',
     ],
     zip_safe=False,
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,11 @@ labext_name = "globus-jupyterlab"
 data_files_spec = [
     ("share/jupyter/labextensions/%s" % labext_name, str(lab_path.relative_to(HERE)), "**"),
     ("share/jupyter/labextensions/%s" % labext_name, str("."), "install.json"),
+    ("etc/jupyter/jupyter_server_config.d",
+     "jupyter-config/server-config", "globus_jupyterlab.json"),
+    # For backward compatibility with notebook server
+    ("etc/jupyter/jupyter_notebook_config.d",
+     "jupyter-config/nb-config", "globus_jupyterlab.json"),
 ]
 
 long_description = (HERE / "README.md").read_text()

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -1,0 +1,39 @@
+import { URLExt } from '@jupyterlab/coreutils';
+
+import { ServerConnection } from '@jupyterlab/services';
+
+/**
+ * Call the API extension
+ *
+ * @param endPoint API REST end point for the extension
+ * @param init Initial values for the request
+ * @returns The response body interpreted as JSON
+ */
+export async function requestAPI<T>(
+  endPoint = '',
+  init: RequestInit = {}
+): Promise<T> {
+  // Make request to Jupyter API
+  const settings = ServerConnection.makeSettings();
+  const requestUrl = URLExt.join(
+    settings.baseUrl,
+    'globus-jupyterlab',
+    endPoint
+  );
+
+  let response: Response;
+  try {
+    console.log('making request to: ' + requestUrl);
+    response = await ServerConnection.makeRequest(requestUrl, init, settings);
+  } catch (error) {
+    throw new ServerConnection.NetworkError(error);
+  }
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new ServerConnection.ResponseError(response, data.message);
+  }
+
+  return data;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {IDocumentManager} from '@jupyterlab/docmanager';
 import {IFileBrowserFactory} from "@jupyterlab/filebrowser";
 import {GlobusWidgetManager} from "./globus/widget_manager";
 
+import { requestAPI } from './handler';
 /**
  * Globus plugin
  */
@@ -15,7 +16,7 @@ export const globus: JupyterFrontEndPlugin<void> = {
     activate: activateGlobus
 };
 
-function activateGlobus(app: JupyterFrontEnd, manager: IDocumentManager, restorer: ILayoutRestorer, factory: IFileBrowserFactory) {
+async function activateGlobus(app: JupyterFrontEnd, manager: IDocumentManager, restorer: ILayoutRestorer, factory: IFileBrowserFactory) {
     // Writes and executes a command inside of the default terminal in JupyterLab.
     // console.log(app.info);
     // app.serviceManager.terminals.startNew().then(session => {
@@ -29,6 +30,16 @@ function activateGlobus(app: JupyterFrontEnd, manager: IDocumentManager, restore
     let home: GlobusHome = new GlobusHome(widgetManager);
     restorer.add(home, 'globus-home');
     app.shell.add(home, 'left');
+
+    console.log('JupyterLab extension server-extension-example is activated!');
+
+    // GET request
+    try {
+      const data = await requestAPI<any>('config');
+      console.log('Fetching basic data about the notebook server environment:', data);
+    } catch (reason) {
+      console.error(`Error on GET /globus_jupyterlab/config.\n${reason}`);
+    }
 }
 
 /**


### PR DESCRIPTION
This is loosely based on how Jupyterhub organizes its handlers,
where each module defines `default_handlers` and they are bundled
together by the app.

Most of the code here is just stubs, with the exception of config
which will fetch the globus endpoint for the system its installed
on.