### PR TITLE
Feature: Manual copy code

### DIFF
--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -57,6 +57,13 @@ class GlobusConfig():
     def get_collection_base_path(self) -> str:
         return os.getcwd()
 
+    def is_hub(self) -> bool:
+        """Returns True if JupyterLab is running in a 'hub' environment, false otherwise"""
+        # There may be a better way to ensure this is a hub environment. It may be possible
+        # that the server admin is running without users and hub tokens are disabled, and this
+        # could possibly return a false negative, although that should be unlikely.
+        return os.getenv('JUPYTERHUB_USER', None) and self.get_hub_token()
+
     def get_oauthenticator_data(self) -> dict:
             # Fetch any info set by the Globus Juptyterhub OAuthenticator
         oauthonticator_env = os.getenv('GLOBUS_DATA')

--- a/globus_jupyterlab/handlers/config.py
+++ b/globus_jupyterlab/handlers/config.py
@@ -16,6 +16,7 @@ class Config(BaseAPIHandler):
             'collection_id': self.gconfig.get_local_globus_collection(),
             'collection_base_path': self.gconfig.get_collection_base_path(),
             'is_gcp': self.gconfig.is_gcp(),
+            'is_hub': self.gconfig.is_hub(),
             'is_logged_in': self.login_manager.is_logged_in(),
             'collection_id_owner': self.gconfig.get_collection_id_owner(),
         }

--- a/globus_jupyterlab/models.py
+++ b/globus_jupyterlab/models.py
@@ -1,4 +1,5 @@
 from typing import List
+from enum import Enum
 from pydantic import BaseModel
 
 class TransferItemsModel(BaseModel):
@@ -11,3 +12,15 @@ class TransferModel(BaseModel):
     source_endpoint: str
     destination_endpoint: str
     transfer_items: List[TransferItemsModel]
+
+
+class StatusEnum(str, Enum):
+    success = 'success'
+    failure = 'failure'
+
+
+class AuthResponseModel(BaseModel):
+    result: StatusEnum = StatusEnum.success
+    status_code: int = 200
+    code: str = 'Success'
+    message: str = 'The action completed successfully'


### PR DESCRIPTION
**NOTE**: This PR is based on #21, so marking it as a draft until that's merged. 

We discovered it isn't always possible to automatically copy the
auth code due to the way JupyterHub mounts its urls. Since the user
changes as part of the URL, a static redirect_uri won't work. For Example:

https://my-hub.com/user/nick/lab

where `nick` is a dynamic URL for each user that starts a single
user server. This results in a different redirect_uri for each user.

The changes here allow a manual code copy, which fixes this problem.