### PR TITLE
feat: Support Mapped collections via re-login with data_access scope

### DIFF
--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -57,6 +57,13 @@ class GlobusConfig():
     def get_collection_base_path(self) -> str:
         return os.getcwd()
 
+    def is_hub(self) -> bool:
+        """Returns True if JupyterLab is running in a 'hub' environment, false otherwise"""
+        # There may be a better way to ensure this is a hub environment. It may be possible
+        # that the server admin is running without users and hub tokens are disabled, and this
+        # could possibly return a false negative, although that should be unlikely.
+        return os.getenv('JUPYTERHUB_USER', None) and self.get_hub_token()
+
     def get_oauthenticator_data(self) -> dict:
             # Fetch any info set by the Globus Juptyterhub OAuthenticator
         oauthonticator_env = os.getenv('GLOBUS_DATA')

--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -2,8 +2,10 @@ import os
 import logging
 import pickle
 import base64
+from typing import List
 
 import globus_sdk
+from globus_sdk.scopes import TransferScopes
 
 log = logging.getLogger(__name__)
 
@@ -26,8 +28,12 @@ class GlobusConfig():
     def get_redirect_uri(self) -> str:
         return os.getenv('GLOBUS_REDIRECT_URI', None)
 
-    def get_scopes(self) -> str:
-        return os.getenv('GLOBUS_SCOPES', None)
+    def get_transfer_submission_scope(self) -> str:
+        custom_scope = os.getenv('GLOBUS_TRANSFER_SUBMISSION_SCOPE', None)
+        return custom_scope or TransferScopes.all
+
+    def get_transfer_submission_url(self) -> str:
+        return os.getenv('GLOBUS_TRANSFER_SUBMISSION_URL', None)
 
     def get_named_grant(self) -> str:
         return os.getenv('GLOBUS_NAMED_GRANT', 'Globus JupyterLab')

--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -18,6 +18,9 @@ class GlobusConfig():
     api token if it is available.
     """
     default_client_id = '64d2d5b3-b77e-4e04-86d9-e3f143f563f7'
+    base_scopes = [
+        TransferScopes.all
+    ]
 
     def get_client_id(self) -> str:
         return os.getenv('GLOBUS_CLIENT_ID', self.default_client_id)
@@ -28,9 +31,15 @@ class GlobusConfig():
     def get_redirect_uri(self) -> str:
         return os.getenv('GLOBUS_REDIRECT_URI', None)
 
+    def get_scopes(self) -> List[str]:
+        scopes = self.base_scopes.copy()
+        custom_transfer_scope = self.get_transfer_submission_scope()
+        if custom_transfer_scope:
+            scopes.append(custom_transfer_scope)
+        return scopes
+
     def get_transfer_submission_scope(self) -> str:
-        custom_scope = os.getenv('GLOBUS_TRANSFER_SUBMISSION_SCOPE', None)
-        return custom_scope or TransferScopes.all
+        return os.getenv('GLOBUS_TRANSFER_SUBMISSION_SCOPE', None)
 
     def get_transfer_submission_url(self) -> str:
         return os.getenv('GLOBUS_TRANSFER_SUBMISSION_URL', None)

--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -1,10 +1,37 @@
 
 import json
+import urllib
 import tornado
 import globus_sdk
 import pydantic
 from globus_jupyterlab.handlers.base import BaseAPIHandler
 from globus_jupyterlab.models import TransferModel
+
+
+class GCSAuthMixin(BaseAPIHandler):
+    """Mixin for handling 403 responses from querying a Globus Connect Server which
+    requries the data_access scope. This mixin will introspect the query params for
+    the collection using `gcs_query_param`. This value needs to match the expected
+    gcs query param or the request will fail.
+
+    For 403 responses, responses will include a login urls with the extended scopes
+    for the data_access scope, for each `base_scope` defined below (by default it
+    is only transfer) Additionally, if a custom transfer submission scope is used,
+    that will also be automatically requested."""
+
+    gcs_query_param = 'endpoint'
+    base_scopes = [globus_sdk.scopes.TransferScopes.all]
+
+    def get_requested_scopes(self):
+        collection = self.get_query_argument(self.gcs_query_param)
+        gcs_scope = globus_sdk.scopes.GCSCollectionScopeBuilder(collection)
+        requested_scopes = [f'{base_scope}[{gcs_scope.data_access}]' for base_scope in self.base_scopes]
+
+        submission_scope = self.gconfig.get_transfer_submission_scope()
+        if submission_scope:
+            requested_scopes.append(f'{submission_scope}[{gcs_scope.data_access}]')
+
+        return ' '.join(requested_scopes)
 
 
 class GetMethodTransferAPIEndpoint(BaseAPIHandler):
@@ -13,14 +40,16 @@ class GetMethodTransferAPIEndpoint(BaseAPIHandler):
     mandatory_args = []
     optional_args = {}
 
+    def get_requested_scopes(self):
+        return ' '.join(self.gconfig.get_scopes())
+
     def get(self):
         response = dict()
         if self.login_manager.is_logged_in() is not True:
             self.set_status(401)
             return self.finish(json.dumps({'error': 'The user is not logged in'}))
         try:
-            authorizer = self.login_manager.get_authorizer(
-                'transfer.api.globus.org')
+            authorizer = self.login_manager.get_authorizer('transfer.api.globus.org')
             tc = globus_sdk.TransferClient(authorizer=authorizer)
             method = getattr(tc, self.globus_sdk_method)
             args, kwargs = self.get_args()
@@ -28,7 +57,12 @@ class GetMethodTransferAPIEndpoint(BaseAPIHandler):
             return self.finish(json.dumps(response.data))
         except globus_sdk.GlobusAPIError as gapie:
             self.set_status(gapie.http_status)
-            return self.finish(json.dumps({'error': gapie.code, 'details': gapie.message}))
+            response = {'error': gapie.code, 'details': gapie.message}
+            if gapie.http_status in [401, 403]:
+                login_url = self.reverse_url('login')
+                params = urllib.parse.urlencode({'requested_scopes': self.get_requested_scopes()})
+                response['login_url'] = f'{login_url}?{params}'
+            return self.finish(json.dumps(response))
 
     def get_args(self):
         args = [self.get_query_argument(arg) for arg in self.mandatory_args]
@@ -70,7 +104,7 @@ class SubmitTransfer(BaseAPIHandler):
             return self.finish(json.dumps({'error': 'Invalid Input', 'details': ve.json()}))
 
 
-class OperationLS(GetMethodTransferAPIEndpoint):
+class OperationLS(GCSAuthMixin, GetMethodTransferAPIEndpoint):
     """An API Endpoint doing a Globus LS"""
     globus_sdk_method = 'operation_ls'
     mandatory_args = ['endpoint']
@@ -79,7 +113,7 @@ class OperationLS(GetMethodTransferAPIEndpoint):
     }
 
 
-class EndpointSearch(GetMethodTransferAPIEndpoint):
+class EndpointSearch(GCSAuthMixin, GetMethodTransferAPIEndpoint):
     """An API Endpoint for searching for collections"""
     globus_sdk_method = 'endpoint_search'
     mandatory_args = []
@@ -94,21 +128,10 @@ class EndpointSearch(GetMethodTransferAPIEndpoint):
     }
 
 
-class EndpointDetail(BaseAPIHandler):
-    def get(self):
-        response = dict()
-        if self.login_manager.is_logged_in() is not True:
-            self.set_status(401)
-            return self.finish(json.dumps({'error': 'The user is not logged in'}))
-        try:
-            authorizer = self.login_manager.get_authorizer(
-                'transfer.api.globus.org')
-            tc = globus_sdk.TransferClient(authorizer=authorizer)
-            response = tc.get_endpoint(self.get_query_argument('endpoint_id', None))
-            return self.finish(json.dumps(response.data))
-        except globus_sdk.GlobusAPIError as gapie:
-            self.set_status(gapie.http_status)
-            return self.finish(json.dumps({'error': gapie.code, 'details': gapie.message}))
+class EndpointDetail(GCSAuthMixin, GetMethodTransferAPIEndpoint):
+    globus_sdk_method = 'get_endpoint'
+    mandatory_args = ['endpoint']
+    optional_args = {}
 
 
 default_handlers = [

--- a/globus_jupyterlab/handlers/config.py
+++ b/globus_jupyterlab/handlers/config.py
@@ -16,6 +16,7 @@ class Config(BaseAPIHandler):
             'collection_id': self.gconfig.get_local_globus_collection(),
             'collection_base_path': self.gconfig.get_collection_base_path(),
             'is_gcp': self.gconfig.is_gcp(),
+            'is_hub': self.gconfig.is_hub(),
             'is_logged_in': self.login_manager.is_logged_in(),
             'collection_id_owner': self.gconfig.get_collection_id_owner(),
         }

--- a/globus_jupyterlab/models.py
+++ b/globus_jupyterlab/models.py
@@ -1,4 +1,5 @@
 from typing import List
+from enum import Enum
 from pydantic import BaseModel
 
 class TransferItemsModel(BaseModel):
@@ -11,3 +12,15 @@ class TransferModel(BaseModel):
     source_endpoint: str
     destination_endpoint: str
     transfer_items: List[TransferItemsModel]
+
+
+class StatusEnum(str, Enum):
+    success = 'success'
+    failure = 'failure'
+
+
+class AuthResponseModel(BaseModel):
+    result: StatusEnum = StatusEnum.success
+    status_code: int = 200
+    code: str = 'Success'
+    message: str = 'The action completed successfully'

--- a/src/components/Endpoint.tsx
+++ b/src/components/Endpoint.tsx
@@ -34,7 +34,7 @@ const Endpoint = (props) => {
 
   const getEndpoint = async (endpointID) => {
     try {
-      let response = await fetch(`/globus-jupyterlab/endpoint_detail?endpoint_id=${endpointID}`, {
+      let response = await fetch(`/globus-jupyterlab/endpoint_detail?endpoint=${endpointID}`, {
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
@@ -73,6 +73,11 @@ const Endpoint = (props) => {
       }
       setEndpointList(listItems);
     } catch (error) {
+      /* Note: This probably isn't a great UX to simply pop up a login page, but it
+      does demonstrate the base functionality for picking endpoints */
+      if ('login_url' in error) {
+        window.open(error.login_url, 'Globus Login', 'height=600,width=800').focus();
+      }
       setAPIError(error);
     }
     setLoading(false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,12 @@ async function activateGlobus(app: JupyterFrontEnd, manager: IDocumentManager, r
       const endpoint_search = await requestAPI<any>('endpoint_search?filter_fulltext=tutorial');
       console.log('Endpoint Search: ', endpoint_search);
 
+      const endpoint_autoactivate = await requestAPI<any>('endpoint_autoactivate', {
+        body: JSON.stringify({'endpoint_id': 'ddb59aef-6d04-11e5-ba46-22000b92c6ec'}),
+        method: 'POST',
+      });
+      console.log(endpoint_autoactivate);
+
       const transferRequest = {
         //Globus Tutorial Endpoint 1
         'source_endpoint': 'ddb59aef-6d04-11e5-ba46-22000b92c6ec',


### PR DESCRIPTION
These changes enable discovering the scopes requried to access an
endpoint which require an extra GCS data_access scope. This isn't always
a dependent scope on the transfer scope, since we want to allow custom
submissions in this case, so the extra GET endpoint will automatically
determine the correct 'base' scope to use and return a valid login scope
including the GCS data_access dependency.

**Dependent on #31**