### PR TITLE
Build docker image using packaged version instead of dev version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,15 +23,16 @@ RUN chown -R jovyan /custom_extensions/globus_jupyterlab
 
 USER $NB_USER
 
-RUN python -m pip install jupyterlab jupyter-packaging globus-sdk pydantic
+RUN python -m pip install jupyterlab build jupyter-packaging globus-sdk pydantic
 
 # Support overriding a package or two through passed docker --build-args.
-ARG PIP_OVERRIDES="jupyterhub==1.3.0"
+ARG PIP_OVERRIDES="jupyterhub==1.5.0"
 RUN if [[ -n "$PIP_OVERRIDES" ]]; then \
         pip install --no-cache-dir $PIP_OVERRIDES; \
     fi
 
-RUN jupyter labextension develop /custom_extensions/globus_jupyterlab --overwrite
+RUN python -m build /custom_extensions/globus_jupyterlab
+RUN python -m pip install /custom_extensions/globus_jupyterlab/dist/*.tar.gz
 # RUN jupyter serverextension enable --py nbgitpuller --sys-prefix
 RUN jupyter serverextension enable globus_jupyterlab
 


### PR DESCRIPTION
Fixes a problem where the server extension would not get picked up on hub start. 