### PR TITLE
fix: server extension hiding manual copy-code step

### DIFF
--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -25,6 +25,7 @@ class GlobusConfig():
     base_scopes = [
         TransferScopes.all
     ]
+    globus_auth_code_redirect_url = 'https://auth.globus.org/v2/web/auth-code'
 
     def get_refresh_tokens(self) -> bool:
         """
@@ -162,7 +163,10 @@ class GlobusConfig():
 
         Configurable via evironment variable: GLOBUS_REDIRECT_URIS
         """
-        return os.getenv('GLOBUS_REDIRECT_URI', None)
+        redirect = os.getenv('GLOBUS_REDIRECT_URI', None)
+        if redirect is None and self.is_hub():
+            redirect = self.globus_auth_code_redirect_url
+        return redirect
 
     def is_gcp(self) -> str:
         return bool(self.get_gcp_collection())

--- a/globus_jupyterlab/handlers/config.py
+++ b/globus_jupyterlab/handlers/config.py
@@ -12,11 +12,14 @@ class Config(BaseAPIHandler):
     @tornado.web.authenticated
     def get(self, *args, **kwargs):
         
+        copy_required = self.gconfig.get_redirect_uri() == self.gconfig.globus_auth_code_redirect_url
         data = {
+            # TODO: Make these configurable
             'collection_id': self.gconfig.get_local_globus_collection(),
             'collection_base_path': self.gconfig.get_collection_base_path(),
             'is_gcp': self.gconfig.is_gcp(),
             'is_hub': self.gconfig.is_hub(),
+            'is_manual_copy_code_required': copy_required,
             'is_logged_in': self.login_manager.is_logged_in(),
             'collection_id_owner': self.gconfig.get_collection_id_owner(),
         }

--- a/globus_jupyterlab/handlers/login.py
+++ b/globus_jupyterlab/handlers/login.py
@@ -16,8 +16,6 @@ class PKCEFlowManager(BaseAPIHandler):
     AuthCallback handlers, such as generating/storing/retrieving the PKCE
     verifier and constructing the redirect URL.
     """
-    GLOBUS_AUTH_CODE_REDIRECT_URI = 'https://auth.globus.org/v2/web/auth-code'
-
     @staticmethod
     def generate_verifier():
         return base64.urlsafe_b64encode(os.urandom(32)).decode("utf-8").rstrip("=")
@@ -25,17 +23,14 @@ class PKCEFlowManager(BaseAPIHandler):
     def get_redirect_uri(self):
         redirect_uri = self.gconfig.get_redirect_uri()
         if not redirect_uri:
-            if self.gconfig.is_hub():
-                redirect_uri = self.GLOBUS_AUTH_CODE_REDIRECT_URI
-            else:
-                self.log.info(
-                    'No redirect URI configured, determining automatically...')
-                redirect_uri = urllib.parse.urlunparse((
-                    self.request.protocol,
-                    self.request.host,
-                    self.reverse_url('redirect_uri'),
-                    '', '', ''
-                ))
+            self.log.info(
+                'No redirect URI configured, determining automatically...')
+            redirect_uri = urllib.parse.urlunparse((
+                self.request.protocol,
+                self.request.host,
+                self.reverse_url('redirect_uri'),
+                '', '', ''
+            ))
         self.log.debug(f'Using redirect URI: {redirect_uri}')
         return redirect_uri
 


### PR DESCRIPTION
Previously it wasn't easy to know whether the server extension would
require a manual copy code. This is now exposed in the config fetch,
so the front end can determine which method it needs to use.