### PR TITLE
Non-functional endpoint set to the incorrect value

### DIFF
--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -225,7 +225,7 @@ class EndpointSearch(GCSAuthMixin, GetMethodTransferAPIEndpoint):
         "filter_scope": None,
         "filter_owner_id": None,
         "filter_host_endpoint": None,
-        "filter_non_functional": True,
+        "filter_non_functional": False,
         "limit": 10,
         "offset": 0,
     }


### PR DESCRIPTION
The previous default setting made searches only return non-functional
endpoints. Setting this to 'False' instead results in expected behavior