### PR TITLE
fix: Frontend not prompting for login when required

### DIFF
--- a/src/components/Endpoint.tsx
+++ b/src/components/Endpoint.tsx
@@ -62,10 +62,11 @@ const Endpoint = (props) => {
       const listItems = await requestAPI<any>(url);
       setEndpointList(listItems);
     } catch (error) {
+      let error_response = await error.response.json()
       /* Note: This probably isn't a great UX to simply pop up a login page, but it
       does demonstrate the base functionality for picking endpoints */
-      if ('login_url' in error) {
-        window.open(error.login_url, 'Globus Login', 'height=600,width=800').focus();
+      if ('login_url' in error_response) {
+        window.open(error_response.login_url, 'Globus Login', 'height=600,width=800').focus();
       }
       setAPIError(error);
     }

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -29,11 +29,9 @@ export async function requestAPI<T>(
     throw new ServerConnection.NetworkError(error);
   }
 
-  const data = await response.json();
-
   if (!response.ok) {
-    throw new ServerConnection.ResponseError(response, data.message);
+    throw new ServerConnection.ResponseError(response);
   }
 
-  return data;
+  return await response.json();
 }


### PR DESCRIPTION
The newer exception handler pre-parsed key info in the response and
'locked' it when raising exceptions. This resulted in downstream
error code not being able to reference the 'login' url needed to
resolve the original problem.