### PR TITLE
feat: Partial support for using GCS v4 endpoints which need activation

### DIFF
--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -79,7 +79,7 @@ class GCSAuthMixin(AutoAuthURLMixin):
         if self.check_gcsv4_requires_activation(exception):
             endpoint = self.get_query_argument(self.gcs_query_param, None)
             return f"https://app.globus.org/file-manager?origin_id={endpoint}"
-        return super().get_login_url()
+        return super().get_globus_login_url(exception)
 
     def check_gcsv4_requires_activation(
         self, exception: globus_sdk.GlobusAPIError

--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -75,6 +75,12 @@ class GCSAuthMixin(AutoAuthURLMixin):
         "check_gcsv54_ha_not_from_allowed_domain",
     ]
 
+    def get_globus_login_url(self, exception: globus_sdk.GlobusAPIError):
+        if self.check_gcsv4_requires_activation(exception):
+            endpoint = self.get_query_argument(self.gcs_query_param, None)
+            return f"https://app.globus.org/file-manager?origin_id={endpoint}"
+        return super().get_login_url()
+
     def check_gcsv4_requires_activation(
         self, exception: globus_sdk.GlobusAPIError
     ) -> bool:


### PR DESCRIPTION
This change makes Jupyterlab link to the webapp in order to log users
into gcs v4 endpoints. In the future, we'll add more direct support for
v4 endpoints by connecting directly to the endpoint instead of going
through the webapp.