### PR TITLE
Transfer fixes

### DIFF
--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -192,9 +192,6 @@ class GlobusSDKWrapper(AutoAuthURLMixin):
                     self.log.error("Failed to generate login URL", exc_info=True)
                     response["error"] = le.__class__.__name__
                     response["details"] = str(le)
-            from pprint import pprint
-
-            pprint(response)
             return self.finish(json.dumps(response))
 
 

--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -168,18 +168,20 @@ class GlobusSDKWrapper(AutoAuthURLMixin):
     def get_globus_sdk_args(self):
         return [], {}
 
+    def transfer_client_call(self):
+        authorizer = self.login_manager.get_authorizer("transfer.api.globus.org")
+        tc = globus_sdk.TransferClient(authorizer=authorizer)
+        method = getattr(tc, self.globus_sdk_method)
+        args, kwargs = self.get_globus_sdk_args()
+        return method(*args, **kwargs).data
+
     def sdk_wrapper_call(self):
         response = dict()
         if self.login_manager.is_logged_in() is not True:
             self.set_status(401)
             return self.finish(json.dumps({"error": "The user is not logged in"}))
         try:
-            authorizer = self.login_manager.get_authorizer("transfer.api.globus.org")
-            tc = globus_sdk.TransferClient(authorizer=authorizer)
-            method = getattr(tc, self.globus_sdk_method)
-            args, kwargs = self.get_globus_sdk_args()
-            response = method(*args, **kwargs)
-            return self.finish(json.dumps(response.data))
+            return self.finish(json.dumps(self.transfer_client_call()))
         except globus_sdk.GlobusAPIError as gapie:
             self.set_status(gapie.http_status)
             response = {"error": gapie.code, "details": gapie.message}
@@ -234,18 +236,23 @@ class EndpointAutoactivate(POSTMethodTransferAPIEndpoint):
     optional_args = {}
 
 
-class SubmitTransfer(GCSAuthMixin):
+class SubmitTransfer(GCSAuthMixin, POSTMethodTransferAPIEndpoint):
     """An API Endpoint for submitting Globus Transfers."""
 
-    @tornado.web.authenticated
-    def post(self):
+    globus_sdk_method = "submit_transfer"
+    mandatory_args = []
+    optional_args = {}
+
+    def transfer_client_call(self):
+        """Transfer submission is a bit more complex than the other wrapped calls. For one, it validates
+        a complex POST document through pydantic instead of taking simple args. Second, the call into the
+        Transfer Client requires a couple helper classes to complete, including both globus_sdk.TransferClient
+        and globus_sdk.TransferModel. Third, the globus_sdk may not be used in the case that a separate
+        service is handling the actual transfer, in which case the document needs to be forwarded instead.
+
+        Auth errors are the only unchanged mechanism. If the remote endpoint isn't active or requires
+        re-auth, the procedure is the same as other operation methods.
         """
-        Attempt to submit a transfer with tokens previously loaded by a user.
-        """
-        response = dict()
-        if self.login_manager.is_logged_in() is not True:
-            self.set_status(401)
-            return self.finish(json.dumps({"error": "The user is not logged in"}))
         try:
             post_data = json.loads(self.request.body)
             self.log.debug("Checking transfer document")
@@ -254,7 +261,6 @@ class SubmitTransfer(GCSAuthMixin):
                 response = self.submit_custom_transfer(tm)
             else:
                 response = self.submit_normal_transfer(tm)
-
             return self.finish(json.dumps(response))
         except pydantic.ValidationError as ve:
             self.set_status(400)
@@ -262,12 +268,6 @@ class SubmitTransfer(GCSAuthMixin):
             return self.finish(
                 json.dumps({"error": "Invalid Input", "details": ve.json()})
             )
-        except globus_sdk.GlobusAPIError as gapie:
-            self.set_status(gapie.http_status)
-            response = {"error": gapie.code, "details": gapie.message}
-            if gapie.http_status in [401, 403]:
-                response["login_url"] = self.get_globus_login_url()
-            return self.finish(json.dumps(response))
 
     def submit_custom_transfer(self, transfer_data: TransferModel):
         url = self.gconfig.get_transfer_submission_url()

--- a/globus_jupyterlab/tests/api/test_transfer.py
+++ b/globus_jupyterlab/tests/api/test_transfer.py
@@ -102,3 +102,33 @@ def test_401_login_url_with_custom_submission_scope(
         "http://myscope[https://auth.globus.org/scopes/foo/data_access]"
         in requested_scopes
     )
+
+
+@pytest.mark.gen_test
+def test_transfer_submission_normal(
+    http_client, base_url, transfer_client, transfer_data, sdk_error, logged_in
+):
+    body = json.dumps(
+        {"source_endpoint": "mysource", "destination_endpoint": "mydest", "DATA": []}
+    )
+    response = yield http_client.fetch(
+        base_url + f"/submit_transfer", raise_error=False, method="POST", body=body
+    )
+    assert response.code == 200
+
+
+@pytest.mark.gen_test
+def test_401_transfer_submission_normal(
+    http_client, base_url, transfer_client, transfer_data, sdk_error, logged_in
+):
+    transfer_client.submit_transfer.side_effect = sdk_error(
+        "401 error!", http_status=401
+    )
+    body = json.dumps(
+        {"source_endpoint": "mysource", "destination_endpoint": "mydest", "DATA": []}
+    )
+    response = yield http_client.fetch(
+        base_url + f"/submit_transfer", raise_error=False, method="POST", body=body
+    )
+    error = json.loads(response.body.decode("utf-8"))
+    assert "login_url" in error

--- a/globus_jupyterlab/tests/conftest.py
+++ b/globus_jupyterlab/tests/conftest.py
@@ -75,7 +75,32 @@ def native_client(monkeypatch) -> globus_sdk.NativeAppAuthClient:
 def transfer_client(monkeypatch) -> globus_sdk.TransferClient:
     """Mock the tranfer client, return the class instance"""
     monkeypatch.setattr(globus_sdk, "TransferClient", Mock())
-    return globus_sdk.TransferClient.return_value
+    inst = globus_sdk.TransferClient.return_value
+
+    class MockData:
+        data = {"mock_transfer": "data"}
+
+    inst.submit_transfer.return_value = MockData()
+    return inst
+
+
+@pytest.fixture
+def transfer_data(monkeypatch) -> globus_sdk.TransferClient:
+    """Mock the tranfer data, return the class instance"""
+
+    class MockTransferData:
+        def __init__(self, tc, source, dest):
+            self.data = {
+                "source_endpoint": source,
+                "destination_endpoint": dest,
+                "DATA": [],
+            }
+
+        def add_item(self, src, dest, recursive=False):
+            self.data.append((src, dest, recursive))
+
+    monkeypatch.setattr(globus_sdk, "TransferData", MockTransferData)
+    return globus_sdk.TransferData
 
 
 @pytest.fixture


### PR DESCRIPTION
Removed some duplicate transfer submission error checking to re-use
the standard GCS Auth class, which can catch a wider swath of errors
that can come back from various GCS endpoints.

Also, Transfer Submissions previously weren't handling 401s correctly
by not passing exception info. This has been fixed by removing the
old code and replacing it with the GCS class above.