### PR TITLE
fix: Possible infinite login redirect on HA Collections

### DIFF
--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -5,7 +5,7 @@ import base64
 from typing import List
 
 import globus_sdk
-from globus_sdk.scopes import TransferScopes
+from globus_sdk.scopes import TransferScopes, AuthScopes
 
 log = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class GlobusConfig:
     """
 
     default_client_id = "64d2d5b3-b77e-4e04-86d9-e3f143f563f7"
-    base_scopes = [TransferScopes.all]
+    base_scopes = [TransferScopes.all, AuthScopes.profile, AuthScopes.openid]
     globus_auth_code_redirect_url = "https://auth.globus.org/v2/web/auth-code"
 
     @property
@@ -75,6 +75,18 @@ class GlobusConfig:
         In those cases, dependent scopes must be added manually.
         """
         scopes = self.base_scopes.copy()
+        custom_transfer_scope = self.get_transfer_submission_scope()
+        if custom_transfer_scope:
+            scopes.append(custom_transfer_scope)
+        return scopes
+
+    def get_transfer_scopes(self) -> List[str]:
+        """
+        Get all known transfer scopes required by Globus JupyterLab. Typically this
+        is only globus_sdk.scopes.TransferScopes.all, but if GLOBUS_TRANSFER_SUBMISSION_SCOPE
+        is set, it will return a list containing both.
+        """
+        scopes = [TransferScopes.all]
         custom_transfer_scope = self.get_transfer_submission_scope()
         if custom_transfer_scope:
             scopes.append(custom_transfer_scope)

--- a/globus_jupyterlab/tests/api/test_transfer.py
+++ b/globus_jupyterlab/tests/api/test_transfer.py
@@ -53,7 +53,7 @@ def test_get_api(
     [
         (
             GRIDFTP_HA_NOT_FROM_ALLOWED_DOMAIN,
-            "/login?requested_scopes=urn%3Aglobus%3Aauth%3Ascope%3Atransfer.api.globus.org%3Aall&session_required_single_domain=globus.org",
+            "/login?requested_scopes=urn%3Aglobus%3Aauth%3Ascope%3Atransfer.api.globus.org%3Aall&prompt=login&session_required_identities=7d4657a1-0422-409a-a0ee-077f4a6a99a1&session_message=The+collection+you+selected+requires+a+fresh+login",
         ),
         (
             GRIDFTP_S3_CREDENTIALS_REQUIRED_MESSAGE,
@@ -72,6 +72,7 @@ def test_gridftp_login_errors(
     base_url,
     transfer_client,
     sdk_error,
+    auth_client,
     logged_in,
 ):
     transfer_client.operation_ls.side_effect = sdk_error(
@@ -140,6 +141,9 @@ def test_401_login_url_with_custom_submission_scope(
     error = json.loads(response.body.decode("utf-8"))
     query_params = parse_qs(urlparse(error["login_url"]).query)
     requested_scopes = query_params["requested_scopes"][0]
+
+    # There should be only two scopes given data_access
+    assert len(requested_scopes.split()) == 2
 
     assert query_params["requested_scopes"][0].startswith(
         "urn:globus:auth:scope:transfer.api.globus.org:all"

--- a/globus_jupyterlab/tests/conftest.py
+++ b/globus_jupyterlab/tests/conftest.py
@@ -10,7 +10,12 @@ import tornado.web
 
 from globus_jupyterlab.handlers import get_handlers, HANDLER_MODULES
 from globus_jupyterlab.handlers.base import BaseAPIHandler
-from globus_jupyterlab.tests.mocks import MockGlobusAPIError, MOCK_TOKENS
+from globus_jupyterlab.tests.mocks import (
+    MockGlobusAPIError,
+    MOCK_TOKENS,
+    MOCK_IDENTITIES,
+    SDKResponse,
+)
 from globus_jupyterlab.login_manager import LoginManager
 from globus_jupyterlab.globus_config import GlobusConfig
 
@@ -82,6 +87,15 @@ def transfer_client(monkeypatch) -> globus_sdk.TransferClient:
 
     inst.submit_transfer.return_value = MockData()
     return inst
+
+
+@pytest.fixture
+def auth_client(monkeypatch) -> globus_sdk.AuthClient:
+    """Mock the auth client, return the class instance"""
+    monkeypatch.setattr(globus_sdk, "AuthClient", Mock())
+    inst = globus_sdk.AuthClient.return_value
+    inst.oauth2_userinfo.return_value = SDKResponse(data=MOCK_IDENTITIES)
+    return globus_sdk.AuthClient.return_value
 
 
 @pytest.fixture

--- a/globus_jupyterlab/tests/mocks.py
+++ b/globus_jupyterlab/tests/mocks.py
@@ -1,16 +1,55 @@
 import time
 import re
 
+now_seconds = int(time.time())
+two_days_from_now_seconds = now_seconds * 60 * 60 * 48
+
 MOCK_TOKENS = {
     "transfer.api.globus.org": {
         "access_token": "mock_user_access_token",
-        # Simulate brand new fresh tokens that expire in 48 hours
-        "expires_at_seconds": int(time.time()) + 60 * 60 * 48,
+        "expires_at_seconds": two_days_from_now_seconds,
         "refresh_token": None,
         "resource_server": "transfer.api.globus.org",
         "scope": "urn:globus:auth:scope:transfer.api.globus.org:all",
         "token_type": "Bearer",
-    }
+    },
+    "auth.globus.org": {
+        "access_token": "auth_access_token",
+        "expires_at_seconds": two_days_from_now_seconds,
+        "refresh_token": None,
+        "resource_server": "auth.globus.org",
+        "scope": "openid profile",
+        "token_type": "Bearer",
+    },
+}
+
+MOCK_IDENTITIES = {
+    "sub": "e5446c8f-bf6c-4db1-9e3c-b0987b385172",
+    "organization": "Globus",
+    "name": "Owl Lady",
+    "preferred_username": "theowllady@globusid.org",
+    "identity_provider": "228a7af8-16a2-486c-b212-d8c7860d16e2",
+    "identity_provider_display_name": "Globus ID",
+    "last_authentication": 1654732330,
+    "identity_set": [
+        {
+            "sub": "e5446c8f-bf6c-4db1-9e3c-b0987b385172",
+            "organization": "Globus",
+            "name": "Owl Lady",
+            "username": "theowllady@globusid.org",
+            "identity_provider": "228a7af8-16a2-486c-b212-d8c7860d16e2",
+            "identity_provider_display_name": "Globus ID",
+            "last_authentication": now_seconds,
+        },
+        {
+            "sub": "7d4657a1-0422-409a-a0ee-077f4a6a99a1",
+            "name": "Owl Lady",
+            "username": "theowllady@globus.org",
+            "identity_provider": "04b5377c-3b1a-4e9d-b84c-bdeaa6c2fc1f",
+            "identity_provider_display_name": "Globus Staff",
+            "last_authentication": now_seconds,
+        },
+    ],
 }
 
 


### PR DESCRIPTION
If an HA collection was required and didn't satisfy a user's
last session login time, a new login would be required. However,
the new login didn't enforce prompt=login, which wouldn't enforce
the specified required identity. This has now been fixed.