### PR TITLE
Build fix, eslint 8.4.4 causing build error. Fix with resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
         "stylelint-prettier": "^2.0.0",
         "typescript": "~4.1.3"
     },
+    "resolutions": {
+        "@types/eslint": "8.4.3"
+    },
     "sideEffects": [
         "style/*.css",
         "style/index.js"


### PR DESCRIPTION
There's a problem with the eslint==8.4.4 release, rolling back a
patch version fixes this.