### PR TITLE
feat: Host "Hub" collection support for GCS 5.4 HA and Mapped

### DIFF
--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -134,6 +134,46 @@ class GlobusConfig:
         env = os.getenv("GLOBUS_COLLECTION_PATH", None)
         return env or os.getcwd()
 
+    def get_collection_is_mapped(self) -> str:
+        """
+        Set this if the collection set by GLOBUS_COLLECTION_ID is configured
+        as a (non-HA) mapped collection. This will automatically request a data_access scope
+        as a dependency for transfer (and GLOBUS_TRANSFER_SUBMISSION_SCOPE if set),
+        on logins for the user. If the collection is a High Assurance collection, skip
+        this setting and use GLOBUS_COLLECTION_REQUIRED_DOMAIN instead.
+
+        Configurable via evironment variable: GLOBUS_COLLECTION_IS_MAPPED
+        Default: false
+
+        Acceptable env values:
+
+        * 'true' -- for a true value
+        * 'false' -- for a false value
+        """
+        return self.check_env_boolean("GLOBUS_COLLECTION_IS_MAPPED", default=False)
+
+    def get_collection_required_domain(self) -> str:
+        """
+        Set this if the collection set by GLOBUS_COLLECTION_ID is a GCS v5.4 High
+        Assurance (HA) collection, and requires a session with a specific identity
+        provider. An identity with this domain will be enforced on the user's
+        initial login.
+
+        Note: This setting only satisfies HA requirements for transfer operations on
+        the Globus Collection, but does not prevent users logging in with different
+        identities (Clever users can bypass this requirement). See GLOBUS_CLIENT_ID
+        for registering an app which only requires specific identities.
+
+        Configurable via evironment variable: GLOBUS_COLLECTION_REQUIRED_DOMAIN
+        Default: None (Any identity acceptable)
+
+        Example:
+        export GLOBUS_COLLECTION_REQUIRED_DOMAIN=uchicago.edu
+
+        Ensures all users will login with <user>@uchicago.edu identities
+        """
+        return os.getenv("GLOBUS_COLLECTION_REQUIRED_DOMAIN", None)
+
     def get_transfer_submission_url(self) -> str:
         """
         By default, JupyterLab will start transfers on the user's

--- a/globus_jupyterlab/handlers/config.py
+++ b/globus_jupyterlab/handlers/config.py
@@ -1,9 +1,11 @@
 import json
 import tornado
-from globus_jupyterlab.handlers.base import BaseAPIHandler
+from globus_jupyterlab.handlers.auth import AutoAuthURLMixin
+
+# from globus_jupyterlab.handlers.base import BaseAPIHandler
 
 
-class Config(BaseAPIHandler):
+class Config(AutoAuthURLMixin):
     """API Endpoint for fetching information about how the Juptyerlab Backend is configured.
     Configuration can be customized through the hub, such as by setting the Globus Collection
     where the hub prefers its transfers, or alternatively by the user's local installation if
@@ -22,6 +24,7 @@ class Config(BaseAPIHandler):
             "collection_base_path": self.gconfig.get_collection_path(),
             "is_gcp": self.gconfig.is_gcp(),
             "is_hub": self.gconfig.is_hub(),
+            "login_url": self.get_globus_login_url(),
             "is_manual_copy_code_required": copy_required,
             "is_logged_in": self.login_manager.is_logged_in(),
             "last_login": self.gconfig.last_login,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { PageConfig } from "@jupyterlab/coreutils";
 import { GlobusIcon } from "./utilities";
 import { GlobusWidget } from "./widget";
 import { HubLoginWidget } from "./components/HubLoginWidget";
-import { normalizeURL, requestAPI } from "./handler";
+import { requestAPI } from "./handler";
 
 import "../style/index.css";
 
@@ -97,11 +97,7 @@ async function activateGlobus(
               app.shell.add(hubWidget, "main");
             } else {
               window
-                .open(
-                  normalizeURL("globus-jupyterlab/login"),
-                  "Globus Login",
-                  "height=600,width=800"
-                )
+                .open(config.login_url, "Globus Login", "height=600,width=800")
                 .focus();
             }
 


### PR DESCRIPTION
Previously, it wasn't possible to configure GCS v5.4 HA or mapped
collections due to both requiring either specialized identities or
the extra data_access scope. These are now supported through new
environment variables which will ensure correct login parameters
are set for the respective collection.

This only applies to globus-jupyterlab installed in a JupyterHub
environment.

** Note** This basically works but lacks unit tests. Once those are done I'll 
mark this ready for review.