### PR TITLE
fix: Possible exception if notebook is not installed

### DIFF
--- a/globus_jupyterlab/handlers/__init__.py
+++ b/globus_jupyterlab/handlers/__init__.py
@@ -3,8 +3,8 @@ import logging
 from types import ModuleType
 from typing import List, Tuple
 
-from notebook.utils import url_path_join
-from notebook.base.handlers import APIHandler
+from jupyter_server.base.handlers import APIHandler
+from jupyter_server.utils import url_path_join
 from jupyter_server.serverapp import ServerWebApplication
 from tornado.web import StaticFileHandler, url
 from globus_jupyterlab.handlers import login, config, api

--- a/globus_jupyterlab/handlers/base.py
+++ b/globus_jupyterlab/handlers/base.py
@@ -1,4 +1,4 @@
-from notebook.base.handlers import APIHandler
+from jupyter_server.base.handlers import APIHandler
 from globus_jupyterlab.globus_config import GlobusConfig
 from globus_jupyterlab.login_manager import LoginManager
 


### PR DESCRIPTION
This doesn't appear to cause problems for current versions of
jupyterlab, but it did cause problems for tests. Upgrading to
jupyter-server import versions to ensure they work properly.