### PR TITLE
Add path translation features for collections mounted via NFS on JupyterHub

### DIFF
--- a/docs/jupyterhub.rst
+++ b/docs/jupyterhub.rst
@@ -19,6 +19,25 @@ For example:
 
 See :ref:`config` for a full list of config options.
 
+Shared Mapped Collections
+-------------------------
+
+Support is coming soon!
+
+
+Shared Host Collections
+-----------------------
+
+If using a shared collection, special care needs to be taken to ensure the POSIX location accessible
+by JupyterLab matches the location accessible by the host Globus Collection. Commonly, the home directory
+of the Docker image will be the mount location for external storage, typically ``/home/jovyan``. For Shared collections
+which mount a root directory, this can cause a path mis-match where ``/home/jovyan/foo.txt`` accessible from
+JupyterLab appears as ``/foo.txt`` on the Globus Collection.
+
+See :ref:`config` for the values ``GLOBUS_HOST_POSIX_BASEPATH`` and ``GLOBUS_HOST_COLLECTION_BASEPATH`` for translating
+these paths for transfers at runtime.
+
+
 Kubernetes
 ----------
 

--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -144,6 +144,12 @@ class GlobusConfig:
         env = os.getenv("GLOBUS_COLLECTION_PATH", None)
         return env or os.getcwd()
 
+    def get_posix_basepath(self) -> str:
+        return os.getenv("GLOBUS_POSIX_BASEPATH", "")
+
+    def get_collection_basepath(self) -> str:
+        return os.getenv("GLOBUS_COLLECTION_BASEPATH", "")
+
     def get_transfer_submission_url(self) -> str:
         """
         By default, JupyterLab will start transfers on the user's

--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -144,11 +144,11 @@ class GlobusConfig:
         env = os.getenv("GLOBUS_COLLECTION_PATH", None)
         return env or os.getcwd()
 
-    def get_posix_basepath(self) -> str:
-        return os.getenv("GLOBUS_POSIX_BASEPATH", "")
+    def get_host_posix_basepath(self) -> str:
+        return os.getenv("GLOBUS_HOST_POSIX_BASEPATH", "")
 
-    def get_collection_basepath(self) -> str:
-        return os.getenv("GLOBUS_COLLECTION_BASEPATH", "")
+    def get_host_collection_basepath(self) -> str:
+        return os.getenv("GLOBUS_HOST_COLLECTION_BASEPATH", "")
 
     def get_transfer_submission_url(self) -> str:
         """

--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -145,9 +145,40 @@ class GlobusConfig:
         return env or os.getcwd()
 
     def get_host_posix_basepath(self) -> str:
+        """
+        Configure the base path which JupyterLab uses to access files on a Globus Collection,
+        relative to the path the Globus Collection uses to access files. For example, if
+        the same file is referred to by both the Collection and JupyterLab (POSIX):
+
+        * JupyterLab (POSIX): /home/jovyan/foo.txt
+        * Collection (Globus): /foo.txt
+
+        You may set "GLOBUS_HOST_POSIX_BASEPATH=/home/jovyan". This will ensure a file
+        transferred by JupyterLab "/home/jovyan/foo.txt" will be rewritten to "foo.txt"
+        on transfer, such that the Globus Transfer can complete with the correct path.
+
+        This is typically only needed on Shared collections which mount storage in
+        convienient locations on the provided Docker image but do not match the Collection
+        base path. This usually isn't needed when using Mapped Collections.
+
+        By default when blank or unset, no path translation takes place.
+        """
         return os.getenv("GLOBUS_HOST_POSIX_BASEPATH", "")
 
     def get_host_collection_basepath(self) -> str:
+        """
+        Similar to GLOBUS_HOST_POSIX_BASEPATH, this will prepend a base path on a Globus
+        Collection which isn't visible from JupyterLab (POSIX)
+
+        * JupyterLab (POSIX): foo.txt
+        * Collection (Globus): /shared/foo.txt
+
+        You may set "GLOBUS_HOST_COLLECTION_BASEPATH=/shared". This will ensure a file
+        transferred by JupyterLab "~/foo.txt" will be rewritten to "/shared/foo.txt"
+        on transfer, such that the Globus Transfer can complete with the correct path.
+
+        By default when blank or unset, no path translation takes place.
+        """
         return os.getenv("GLOBUS_HOST_COLLECTION_BASEPATH", "")
 
     def get_transfer_submission_url(self) -> str:

--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -38,15 +38,22 @@ class SubmitTransfer(GCSAuthMixin, POSTMethodTransferAPIEndpoint):
         col_id = self.gconfig.get_collection_id()
         for transfer_items in transfer_model.DATA:
             if transfer_model.source_endpoint == col_id:
-                transfer_items.source_path = self.translate_base_paths(
-                    transfer_items.source_path
+                new_path = self.translate_base_paths(transfer_items.source_path)
+                # TODO: Set this to debug when finished debugging on the hub
+                self.log.info(
+                    f"Translating source path {transfer_items.source_path} --> {new_path}"
                 )
+                transfer_items.source_path = new_path
+
             elif transfer_model.destination_endpoint == col_id:
-                transfer_items.destination_path = self.translate_base_paths(
-                    transfer_items.destination_path
+                new_path = self.translate_base_paths(transfer_items.destination_path)
+                self.log.debug(
+                    f"Translating destination path {transfer_items.destination_path} --> {new_path}"
                 )
+                transfer_items.destination_path = new_path
             else:
                 raise ValueError(f"Non-local endpoint used in transfer {col_id}")
+            self.log.debug(f"Translated path ")
 
     def transfer_client_call(self):
         """Transfer submission is a bit more complex than the other wrapped calls. For one, it validates

--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -28,8 +28,8 @@ class SubmitTransfer(GCSAuthMixin, POSTMethodTransferAPIEndpoint):
 
     def translate_base_paths(self, path: str) -> TransferModel:
         return path.replace(
-            self.gconfig.get_posix_basepath(),
-            self.gconfig.get_collection_basepath(),
+            self.gconfig.get_host_posix_basepath(),
+            self.gconfig.get_host_collection_basepath(),
         )
 
     def translate_transfer_submission(

--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -1,4 +1,5 @@
 import json
+import pathlib
 import globus_sdk
 import pydantic
 import requests
@@ -27,9 +28,18 @@ class SubmitTransfer(GCSAuthMixin, POSTMethodTransferAPIEndpoint):
     optional_args = {}
 
     def translate_base_paths(self, path: str) -> TransferModel:
-        return path.replace(
-            self.gconfig.get_host_posix_basepath(),
-            self.gconfig.get_host_collection_basepath(),
+        """
+        Take the path that JupyterLab generated and translate it into a "Globus" collection acessible
+        path. This is typically needed if the mount path on the collection causes a 'mismatch' in paths
+        between how JupyterLab sees files and the Collection sees files.
+        """
+        host_collection_basepath = pathlib.Path(
+            self.gconfig.get_host_collection_basepath()
+        )
+        transfer_path = pathlib.Path(path)
+        return str(
+            host_collection_basepath
+            / transfer_path.relative_to(self.gconfig.get_host_posix_basepath())
         )
 
     def translate_transfer_submission(

--- a/globus_jupyterlab/handlers/config.py
+++ b/globus_jupyterlab/handlers/config.py
@@ -19,7 +19,8 @@ class Config(BaseAPIHandler):
         data = {
             # TODO: Make these configurable
             "collection_id": self.gconfig.get_collection_id(),
-            "collection_base_path": self.gconfig.get_collection_path(),
+            "gcs_basepath": self.gconfig.get_collection_basepath(),
+            "posix_basepath": self.gconfig.get_posix_basepath(),
             "is_gcp": self.gconfig.is_gcp(),
             "is_hub": self.gconfig.is_hub(),
             "is_manual_copy_code_required": copy_required,

--- a/globus_jupyterlab/handlers/config.py
+++ b/globus_jupyterlab/handlers/config.py
@@ -19,8 +19,9 @@ class Config(BaseAPIHandler):
         data = {
             # TODO: Make these configurable
             "collection_id": self.gconfig.get_collection_id(),
-            "gcs_basepath": self.gconfig.get_collection_basepath(),
-            "posix_basepath": self.gconfig.get_posix_basepath(),
+            "collection_base_path": self.gconfig.get_collection_path(),
+            "host_posix_basepath": self.gconfig.get_host_posix_basepath(),
+            "host_collection_basepath": self.gconfig.get_host_collection_basepath(),
             "is_gcp": self.gconfig.is_gcp(),
             "is_hub": self.gconfig.is_hub(),
             "is_manual_copy_code_required": copy_required,

--- a/globus_jupyterlab/tests/api/test_transfer.py
+++ b/globus_jupyterlab/tests/api/test_transfer.py
@@ -206,7 +206,7 @@ def test_transfer_submission_with_posix_basepath(
     logged_in,
 ):
     monkeypatch.setenv("GLOBUS_COLLECTION_ID", "mysource")
-    monkeypatch.setenv("GLOBUS_POSIX_BASEPATH", "/home/")
+    monkeypatch.setenv("GLOBUS_HOST_POSIX_BASEPATH", "/home/jovyan/")
     transfer_client.submit_transfer.return_value = SDKResponse(
         data={"task_id": "my_taks_id"}
     )

--- a/globus_jupyterlab/tests/conftest.py
+++ b/globus_jupyterlab/tests/conftest.py
@@ -111,7 +111,7 @@ def transfer_data(monkeypatch) -> globus_sdk.TransferClient:
             }
 
         def add_item(self, src, dest, recursive=False):
-            self.data.append((src, dest, recursive))
+            self.data["DATA"].append((src, dest, recursive))
 
     monkeypatch.setattr(globus_sdk, "TransferData", MockTransferData)
     return globus_sdk.TransferData


### PR DESCRIPTION
Includes changes for setting Globus Path translations when using GCS collections mounted in custom locations on a JupyterHub installation.

Mainly setting: GLOBUS_HOST_POSIX_BASEPATH and GLOBUS_HOST_COLLECTION_BASEPATH

Quite a few things missing before this PR is ready:

- [x] Document config options
- [x] Document example configuration with example NFS mounts -- This stuff gets confusing quickly!
- [x] Replace stand-in `.replace()` with better path path-aware function
- [x] Add more unit tests to ensure this works in all cases
- [x] A bit more testing in a JupyterHub deployment