### PR TITLE
Path translation and error handling

### DIFF
--- a/globus_jupyterlab/exc.py
+++ b/globus_jupyterlab/exc.py
@@ -10,6 +10,12 @@ class TransferSubmission(GlobusJupyterlabException):
     pass
 
 
+class InvalidAPIInput(GlobusJupyterlabException):
+    """The user gave input which was invalid"""
+
+    pass
+
+
 class LoginException(GlobusJupyterlabException):
     """There was a problem with the login process"""
 

--- a/globus_jupyterlab/handlers/api/transfer.py
+++ b/globus_jupyterlab/handlers/api/transfer.py
@@ -65,8 +65,7 @@ class SubmitTransfer(GCSAuthMixin, POSTMethodTransferAPIEndpoint):
         for transfer_items in transfer_model.DATA:
             if transfer_model.source_endpoint == col_id:
                 new_path = self.translate_base_paths(transfer_items.source_path)
-                # TODO: Set this to debug when finished debugging on the hub
-                self.log.info(
+                self.log.debug(
                     f"Translating source path {transfer_items.source_path} --> {new_path}"
                 )
                 transfer_items.source_path = new_path
@@ -78,8 +77,9 @@ class SubmitTransfer(GCSAuthMixin, POSTMethodTransferAPIEndpoint):
                 )
                 transfer_items.destination_path = new_path
             else:
-                raise ValueError(f"Non-local endpoint used in transfer {col_id}")
-            self.log.debug(f"Translated path ")
+                raise ValueError(
+                    f"Non-local collection used in transfer, expected '{col_id}' in transfer. The following transfer document is invalid: {transfer_model.json()}"
+                )
 
     def transfer_client_call(self):
         """Transfer submission is a bit more complex than the other wrapped calls. For one, it validates

--- a/globus_jupyterlab/tests/api/test_transfer.py
+++ b/globus_jupyterlab/tests/api/test_transfer.py
@@ -37,17 +37,11 @@ def test_get_api(
     logged_in,
 ):
     setattr(transfer_client, sdk_method, Mock(return_value=SDKResponse()))
-    if expected_status >= 400:
-        with pytest.raises(tornado.httpclient.HTTPClientError) as http_client_error:
-            yield http_client.fetch(base_url + f"/{operation}?{urlencode(input)}")
-        # This seems to be the best way to assert the status code response from tornado. It isn't ideal,
-        # But it should be accurate
-        assert f"HTTP {expected_status}" in str(http_client_error)
-    else:
-        response = yield http_client.fetch(
-            base_url + f"/{operation}?{urlencode(input)}"
-        )
-        assert response.code == 200
+    response = yield http_client.fetch(
+        base_url + f"/{operation}?{urlencode(input)}", raise_error=False
+    )
+    print(response.body.decode("utf-8"))
+    assert response.code == expected_status
 
 
 @pytest.mark.gen_test


### PR DESCRIPTION
This is a combination PR between two semi-related things -- A fix for the last translation feature and more tests, and general error handling for transfer related operations. 

Path translation can raise a user-error when a user attempts to transfer a file/dir outside of the collection share path. In this case, it would be helpful to share the error with the user, so they can possibly move the file/dir into the share path and retry the transfer. An example error looks like this when a user attempts a transfer: 

```
Path foo.txt is not in the subpath of /foo/bar, and is inaccessible via the configured Globus Collection. Consider moving foo.txt into /foo/bar first.
```

One additional improvement we could make is including this 400 error in the response in place of "Bad Request".

<img width="333" alt="Screen Shot 2022-07-15 at 8 15 28 AM" src="https://user-images.githubusercontent.com/865553/179253146-62ba91a7-0eff-4a68-8851-9d202748faef.png">