### PR TITLE
Custom token storage

### DIFF
--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -64,6 +64,21 @@ class GlobusConfig:
         """
         return self.check_env_boolean("GLOBUS_REFRESH_TOKENS", default=False)
 
+    def get_token_storage_path(self) -> str:
+        """
+        Modify the default path of token storage for Globus JupyterLab. This location MUST
+        be only accessible by the logged in Globus User.
+
+        Configurable via evironment variable: GLOBUS_TOKEN_STORAGE_PATH
+
+        Default is: ~/.globus_jupyterlab_tokens.json
+
+        "~" Expands to the local POSIX user, on JupyterHub this is /home/jovyan
+        """
+        return os.getenv(
+            "GLOBUS_TOKEN_STORAGE_PATH", "~/.globus_jupyterlab_tokens.json"
+        )
+
     def get_named_grant(self) -> str:
         """
         Set a custom Named Grant when a user logs into Globus. Changes the pre-filled

--- a/globus_jupyterlab/handlers/base.py
+++ b/globus_jupyterlab/handlers/base.py
@@ -1,3 +1,4 @@
+import pathlib
 from jupyter_server.base.handlers import APIHandler
 from globus_jupyterlab.globus_config import GlobusConfig
 from globus_jupyterlab.login_manager import LoginManager
@@ -7,7 +8,10 @@ globus_config = GlobusConfig()
 
 class BaseAPIHandler(APIHandler):
     gconfig = globus_config
-    login_manager = LoginManager(globus_config.get_client_id())
+    login_manager = LoginManager(
+        globus_config.get_client_id(),
+        pathlib.Path(globus_config.get_token_storage_path()),
+    )
 
 
 class RedirectWebHandler(BaseAPIHandler):

--- a/globus_jupyterlab/tests/conftest.py
+++ b/globus_jupyterlab/tests/conftest.py
@@ -32,7 +32,7 @@ def app(token_storage, monkeypatch):
 
 
 @pytest.fixture
-def logged_in(token_storage) -> SimpleJSONFileAdapter:
+def logged_in(login_manager, token_storage) -> SimpleJSONFileAdapter:
     """Simulate a logged in Globus application"""
     token_storage.tokens = copy.deepcopy(MOCK_TOKENS)
     return token_storage
@@ -182,9 +182,20 @@ def token_storage(monkeypatch) -> SimpleJSONFileAdapter:
         store = Mock()
 
     storage = MockStorage
-    monkeypatch.setattr(LoginManager, "storage_class", MockStorage)
     monkeypatch.setattr(pathlib.Path, "unlink", MockStorage.clear_tokens)
     return storage
+
+
+@pytest.fixture
+def login_manager(monkeypatch, token_storage, login_manager_mocked_storage_check):
+    monkeypatch.setattr(LoginManager, "storage_class", token_storage)
+    return LoginManager("mock_client_id", pathlib.Path("/mock/path"))
+
+
+@pytest.fixture
+def login_manager_mocked_storage_check(monkeypatch):
+    monkeypatch.setattr(LoginManager, "check_storage_path", Mock())
+    return LoginManager.check_storage_path
 
 
 @pytest.fixture(autouse=True)

--- a/globus_jupyterlab/tests/test_login_manager.py
+++ b/globus_jupyterlab/tests/test_login_manager.py
@@ -3,32 +3,32 @@ from unittest.mock import Mock
 import pathlib
 from globus_jupyterlab.login_manager import LoginManager
 from globus_sdk.tokenstorage import SimpleJSONFileAdapter
+from globus_jupyterlab.exc import TokenStorageError
 import globus_sdk
 
 
-def test_login_manager_logged_in(logged_in):
-    lm = LoginManager("client_id")
-    assert lm.is_logged_in() is True
+def test_login_manager_logged_in(logged_in, login_manager):
+    assert login_manager.is_logged_in() is True
 
 
-def test_login_manager_logged_out(logged_out):
-    lm = LoginManager("client_id")
-    assert lm.is_logged_in() is False
+def test_login_manager_logged_out(logged_out, login_manager):
+    assert login_manager.is_logged_in() is False
 
 
-def test_login_manager_tokens_expried(login_expired):
-    lm = LoginManager("client_id")
-    assert lm.is_logged_in() is False
+def test_login_manager_tokens_expried(login_expired, login_manager):
+    assert login_manager.is_logged_in() is False
 
 
-def test_login_manager_refreshes_token(login_expired, login_refresh, monkeypatch):
+def test_login_manager_refreshes_token(
+    login_expired, login_refresh, monkeypatch, login_manager
+):
     monkeypatch.setattr(globus_sdk.RefreshTokenAuthorizer, "ensure_valid_token", Mock())
-    LoginManager("client_id")
+    LoginManager("client_id", pathlib.Path("/foo/bar/mytokens.json"))
     assert globus_sdk.RefreshTokenAuthorizer.ensure_valid_token.called
 
 
 def test_login_manager_clears_tokens_on_failed_refresh(
-    login_expired, login_refresh, monkeypatch
+    login_expired, login_refresh, monkeypatch, login_manager
 ):
     monkeypatch.setattr(globus_sdk, "AuthAPIError", Exception)
     monkeypatch.setattr(
@@ -37,46 +37,57 @@ def test_login_manager_clears_tokens_on_failed_refresh(
         Mock(side_effect=globus_sdk.AuthAPIError),
     )
     monkeypatch.setattr(LoginManager, "clear_tokens", Mock())
-    LoginManager("client_id")
+    LoginManager("client_id", pathlib.Path("/foo/bar/mytokens.json"))
     assert LoginManager.clear_tokens.called
 
 
-def test_login_manager_clear_tokens(pathlib_unlink):
-    LoginManager("client_id").clear_tokens()
+def test_login_manager_clear_tokens(pathlib_unlink, login_manager_mocked_storage_check):
+    LoginManager("client_id", pathlib.Path("/foo/bar/mytokens.json")).clear_tokens()
     assert pathlib_unlink.called
 
 
-def test_login_manager_no_tokens_file(pathlib_unlink):
+def test_login_manager_no_tokens_file(
+    pathlib_unlink, login_manager_mocked_storage_check
+):
     pathlib_unlink.side_effect = FileNotFoundError
-    LoginManager("client_id").clear_tokens()
+    LoginManager("client_id", pathlib.Path("/foo/bar/mytokens.json")).clear_tokens()
     assert pathlib_unlink.called
 
 
-def test_login_manager_store_tokens(monkeypatch):
+def test_login_manager_store_tokens(monkeypatch, login_manager_mocked_storage_check):
     monkeypatch.setattr(SimpleJSONFileAdapter, "store", Mock())
-    LoginManager("client_id").store({})
+    LoginManager("client_id", pathlib.Path("/foo/bar/mytokens.json")).store({})
     assert SimpleJSONFileAdapter.store.called
 
 
-def test_login_manager_revoke_tokens(native_client, logged_in, login_refresh):
+def test_login_manager_revoke_tokens(
+    native_client, logged_in, login_refresh, login_manager
+):
     # Use refresh to simulate also revoking refresh tokens. It doesn't matter if
     # the access_tokens are expired
     # monkeypatch.setattr(globus_sdk.NativeAppAuthClient, "oauth2_revoke_token", Mock())
     num_tokens = len(login_refresh.tokens) * 2
-    LoginManager("client_id").logout()
+    login_manager.logout()
     assert native_client.oauth2_revoke_token.call_count == num_tokens
 
 
-def test_login_manager_logout_clears_tokens(native_client, pathlib_unlink):
-    LoginManager("client_id").logout()
+def test_login_manager_logout_clears_tokens(
+    native_client, pathlib_unlink, login_manager_mocked_storage_check
+):
+    LoginManager("client_id", pathlib.Path("/foo/bar/mytokens.json")).logout()
     assert pathlib_unlink.called
 
 
-def test_login_manager_apply_dependent_scopes():
-    s = LoginManager("client_id").apply_dependent_scopes("foo", ["bar", "baz"])
+def test_login_manager_apply_dependent_scopes(login_manager):
+    s = login_manager.apply_dependent_scopes("foo", ["bar", "baz"])
     assert s == "foo[bar baz]"
 
 
-def test_login_manager_apply_dependent_scopes_twice_error():
+def test_login_manager_apply_dependent_scopes_twice_error(login_manager):
     with pytest.raises(ValueError):
-        LoginManager("client_id").apply_dependent_scopes("foo[bar]", ["baz"])
+        login_manager.apply_dependent_scopes("foo[bar]", ["baz"])
+
+
+def test_login_manager_invalid_path():
+    with pytest.raises(TokenStorageError):
+        LoginManager("client_id", pathlib.Path(""))


### PR DESCRIPTION
Allow for specifying custom locations for token storage. 

Note: This doesn't support in-memory token storage, which would be nice for some cases where the GCS mount is public and there isn't a great location for a local private user store. 