### PR TITLE
docs: Add docs for configuring a hub-managed resource server

### DIFF
--- a/docs/hub-service-transfers.rst
+++ b/docs/hub-service-transfers.rst
@@ -1,0 +1,78 @@
+Hub-Managed Service Transfers
+=============================
+
+By default, JupyterLab submits transfer requests directly to Globus Transfer.
+This behavior is customizable such that JupyterLab submits to a third-party
+Globus Resource Server instead. This is useful when a third-party app needs to
+submit the transfer request to Globus Transfer.
+
+.. code-block:: bash
+
+   export GLOBUS_TRANSFER_SUBMISSION_URL='https://myservice.edu/service/acls-service'
+   export GLOBUS_TRANSFER_SUBMISSION_SCOPE='my_custom_globus_scope'
+   export GLOBUS_TRANSFER_SUBMISSION_IS_HUB_SERVICE=true
+
+With these settings configured, Jupyterlab will request the configured scope above on first login, in addition to the original transfer
+scope. When a user requests a transfer, the request will be submitted to the custom ``URL`` above instead of to Globus Transfer,
+with the following request:
+
+.. code-block:: javascript
+
+    {
+        "globus_token": "my_custom_globus_scopeed_user_access_token",
+        "transfer": {
+            "source_endpoint": "ddb59aef-6d04-11e5-ba46-22000b92c6ec",
+            "destination_endpoint": "ddb59af0-6d04-11e5-ba46-22000b92c6ec",
+            "DATA": [
+                {
+                    "source_path": "/share/godata/file1.txt",
+                    "destination": "~/",
+                    "recursive": false
+                },
+                {
+                    "source_path": "/foo/bar",
+                    "destination": "~/bar",
+                    "recursive": true
+                }
+            ]
+        }
+    }
+
+The custom request is expected to return ``task_id`` at a minimum in a JSON response:
+
+.. code-block::
+
+    {
+        "task_id": “abcdeaef-6d04-11e5-ba46-22000b92c6ec"
+    }
+
+The task ID returned by the service will be used to monitor the task in Globus.
+
+Configuring a Hub-Managed Service
+---------------------------------
+
+The basics of a Hub-Managed service are covered in the `JupyterHub Docs here <https://jupyterhub.readthedocs.io/en/stable/reference/services.html#services>`_.
+
+Creating a service to do custom transfers does not require many additions from the examples shown
+there outside of writing the service itself. As stated in the docs, a Hub-Managed service must be built
+inside the 'hub' container and specified in the config like so:
+
+.. code-block:: yaml
+
+    hub:
+      image:
+        name: myorg/my-custom-k8
+        tag: latest
+        pullPolicy: Always
+
+Flask Example
+-------------
+
+A full example which mirrors the Flask Example in JupyterHub is below. Before running the acls service
+example, refer to the Globus Auth docs for `Creating a Scope <https://docs.globus.org/api/auth/reference/#create_scope>`_
+for your Gloubs App. The client MUST be the one used in the client below. The scope created should be the
+same scope configured in JupyterLab for ``GLOBUS_TRANSFER_SUBMISSION_SCOPE``.
+
+
+.. literalinclude:: ../globus_jupyterlab/tests/k8-testing/hub-service/flask/app.py
+   :language: python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,7 @@ in a JupyterHub environment like `Zero-to-JupyterHub <https://zero-to-jupyterhub
    installation
    gcp
    jupyterhub
+   hub-service-transfers
    config
    CHANGELOG
 

--- a/docs/jupyterhub.rst
+++ b/docs/jupyterhub.rst
@@ -19,27 +19,9 @@ For example:
 
 See :ref:`config` for a full list of config options.
 
-Shared Mapped Collections
--------------------------
 
-Support is coming soon!
-
-
-Shared Host Collections
------------------------
-
-If using a shared collection, special care needs to be taken to ensure the POSIX location accessible
-by JupyterLab matches the location accessible by the host Globus Collection. Commonly, the home directory
-of the Docker image will be the mount location for external storage, typically ``/home/jovyan``. For Shared collections
-which mount a root directory, this can cause a path mis-match where ``/home/jovyan/foo.txt`` accessible from
-JupyterLab appears as ``/foo.txt`` on the Globus Collection.
-
-See :ref:`config` for the values ``GLOBUS_HOST_POSIX_BASEPATH`` and ``GLOBUS_HOST_COLLECTION_BASEPATH`` for translating
-these paths for transfers at runtime.
-
-
-Kubernetes
-----------
+Example in Kubernetes
+---------------------
 
 The Zero-To-JupyterHub the single-user-server is typically run on a pod separate from the hub,
 and so needs to be configured accordingly. See the `User Environment Documentation <https://zero-to-jupyterhub.readthedocs.io/en/latest/jupyterhub/customizing/user-environment.html>`_
@@ -57,52 +39,108 @@ and so needs to be configured accordingly. See the `User Environment Documentati
                 # GLOBUS_COLLECTION_ID will take precedence if both are present.
                 c.OAuthenticator.globus_local_endpoint = '1346ef68-d9b8-4757-a537-47cefb7698e8'
 
+Shared Mapped Collections
+-------------------------
 
-Customized Transfer Submissions
--------------------------------
+Support is coming soon!
 
-By default, JupyterLab submits transfer requests directly to Globus Transfer.
-This behavior is customizable such that JupyterLab submits to a third-party
-Globus Resource Server instead. This is useful when a third-party app needs to
-submit the transfer request to Globus Transfer.
 
-.. code-block:: bash
+Shared Host Collections
+-----------------------
 
-   export GLOBUS_TRANSFER_SUBMISSION_URL='https://myservice/submit-transfer'
-   export GLOBUS_TRANSFER_SUBMISSION_SCOPE='my_custom_globus_scope'
-   export GLOBUS_TRANSFER_SUBMISSION_IS_HUB_SERVICE=true
+If using a shared collection, special care needs to be taken to ensure the POSIX location accessible
+by JupyterLab matches the location accessible by the host Globus Collection. Commonly, the home directory
+of the Docker image will be the mount location for external storage, typically ``/home/jovyan``. For Shared collections
+which mount a root directory, this can cause a path mis-match where ``/home/jovyan/foo.txt`` accessible from
+JupyterLab appears as ``/foo.txt`` on the Globus Collection.
 
-With these settings configured, Jupyterlab will request the configured scope above on first login, in addition to the original transfer
-scope. When a user requests a transfer, the request will be submitted to the custom ``URL`` above instead of to Globus Transfer,
-with the following request:
+An example is below:
 
-.. code-block:: javascript
+.. code-block:: yaml
 
-    {
-        "transfer": {
-            "source_endpoint": "ddb59aef-6d04-11e5-ba46-22000b92c6ec",
-            "destination_endpoint": "ddb59af0-6d04-11e5-ba46-22000b92c6ec",
-            "DATA": [
-                {
-                    "source_path": "/share/godata/file1.txt",
-                    "destination": "~/",
-                    "recursive": false
-                },
-                {
-                    "source_path": "/foo/bar",
-                    "destination": "~/bar",
-                    "recursive": true
-                }
-            ]
-        }
-    }
+  singleuser:
+  defaultUrl: "/lab"
+  extraEnv:
+    JUPYTERHUB_SINGLEUSER_APP: "jupyter_server.serverapp.ServerApp"
+    GLOBUS_COLLECTION_ID: "my-globus-collection-uuid"
+    GLOBUS_HOST_COLLECTION_BASEPATH: "/"
+    GLOBUS_HOST_POSIX_BASEPATH: "/home/jovyan"
+    GLOBUS_TOKEN_STORAGE_PATH: "/private/globus_jupyterlab_tokens.json"
 
-The custom request is expected to return the following response:
 
-.. code-block::
+Now, using the example above, the GCS storage will allow access to all files on the root of the GCS share at ``/``.
+With the share mounted within JupyterLab at ``/home/jovyan``, transferring ``/home/jovyan/foo.txt`` will transfer
+``/foo.txt`` at the time of the Globus Transfer.
 
-    {
-        "task_id": “abcdeaef-6d04-11e5-ba46-22000b92c6ec"
-    }
+.. note::
+    Saving tokens to ``/private/globus_jupyterlab_tokens.json`` requires a custom Docker container for single users where
+    ``/private`` is accessible. Ex: ``RUN mkdir -p /private && chown -R jovyan /private``. Do not use ``/tmp``, it is
+    shared across user environments!
 
-The task ID returned by the service will be used to monitor the task in Globus.
+See :ref:`config` for the values ``GLOBUS_HOST_POSIX_BASEPATH`` and ``GLOBUS_HOST_COLLECTION_BASEPATH`` for translating
+these paths for transfers at runtime.
+
+
+Storage via NFS
+---------------
+
+Storage using NFS on K8s requires custom setup around your k8s cluster. Assuming you
+have GCS already setup to share files over NFS, you will need to configure the proper
+Persistent Volumes and Persistent Volume Claims. This is documented a little in the
+`z2j docs<https://zero-to-jupyterhub.readthedocs.io/en/latest/jupyterhub/customizing/user-storage.html#customizing-user-storage>_`,
+but the excercise is left to the user to create the custom k8 PV and PVCs.
+
+An example is below, but you will need to vary this depending on your deployment:
+
+.. code-block:: yaml
+
+    # kubectl apply -f pv.yaml
+    apiVersion: v1
+    kind: PersistentVolume
+    metadata:
+    name: nfs
+    namespace: lab-test
+    spec:
+    capacity:
+        storage: 1Mi
+    accessModes:
+        - ReadWriteMany
+    nfs:
+        server: my-service
+        path: "/share"
+    mountOptions:
+        - nfsvers=4.2
+
+    # kubectl apply -f pvc.yaml
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+    name: nfs
+    namespace: lab-test
+    spec:
+    accessModes:
+        - ReadWriteMany
+    storageClassName: ""
+    resources:
+        requests:
+        storage: 1Mi
+    volumeName: nfs
+
+In order to mount these shares on the user's single-user-server, configure the single-user
+storage according to the following:
+
+.. code-block:: yaml
+
+  singleuser:
+    storage:
+      type: static
+      extraLabels: {}
+      static:
+        pvcName: nfs
+        # This will mount under the pv path /share to /share/users/shared
+        # subPath: "users/shared"
+      capacity: 10Gi
+
+The above setup will mount external NFS storage to user started single-user-server pods, where
+``/share/users/shared`` is the actual location on the NFS POSIX machine. In order for this to
+match the examples above, make ``/share/users/shared`` the root of your Guest Collection share.

--- a/globus_jupyterlab/tests/k8-testing/README.md
+++ b/globus_jupyterlab/tests/k8-testing/README.md
@@ -2,6 +2,7 @@
 
 You'll need the following secrets file at `jupyterlab-testing-secrets.yaml`, which is used
 by deploy-test.sh to build the jupyter environment.
+
 ```
 
 hub:
@@ -12,4 +13,15 @@ hub:
     GlobusOAuthenticator:
       client_id: 'globus-client-id'
       client_secret: 'globus-client-secret'
+
+
+  services:
+    acls-service:
+      environment:
+        CLIENT_ID: "service-client-id"
+        CLIENT_SECRET: "service-client-secret"
 ```
+
+Note: The hub-service is optional, but requires building a custom Docker image. The same client_id/secret
+may be used for both the hub and service if desiried, however it's important that the client_id of the
+service owns the scope set by `GLOBUS_TRANSFER_SUBMISSION_SCOPE` in JupyterLab.

--- a/globus_jupyterlab/tests/k8-testing/hub-service/Dockerfile
+++ b/globus_jupyterlab/tests/k8-testing/hub-service/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile
-# 0.11.1 is latest stable release at the time of this writing
+# 1.2.0 is latest stable release at the time of this writing
 FROM jupyterhub/k8s-hub:1.2.0
 
 USER root


### PR DESCRIPTION
These changes add docs around setting up a hub-managed resource server. Marking this as a WIP, since I'm not sure the info is quite digestable enough to present to others. The main problem is complexity, I'm not quite sure how much to dig into creating a hub service or creating a scope for a Globus App. Both are complex, and simply linking to docs isn't super helpful for folks interested in this. 

Additionally, the [ACLs service](https://github.com/globus/globus-jupyterlab/blob/eks-resource-server-testing/globus_jupyterlab/tests/k8-testing/hub-service/flask/app.py) turned out to be quite complex, and I don't think that makes a great example. It's over 400 lines, and while it does useful work I think we need a simpler example to simply ensure Auth works as expected. 