### PR TITLE
fix: Mapped collections not working when using a custom resource server

### DIFF
--- a/globus_jupyterlab/globus_config.py
+++ b/globus_jupyterlab/globus_config.py
@@ -24,6 +24,7 @@ class GlobusConfig:
 
     default_client_id = "64d2d5b3-b77e-4e04-86d9-e3f143f563f7"
     base_scopes = [TransferScopes.all, AuthScopes.profile, AuthScopes.openid]
+    transfer_scope = TransferScopes.all
     globus_auth_code_redirect_url = "https://auth.globus.org/v2/web/auth-code"
 
     @property
@@ -107,15 +108,10 @@ class GlobusConfig:
 
     def get_transfer_scopes(self) -> List[str]:
         """
-        Get all known transfer scopes required by Globus JupyterLab. Typically this
-        is only globus_sdk.scopes.TransferScopes.all, but if GLOBUS_TRANSFER_SUBMISSION_SCOPE
-        is set, it will return a list containing both.
+        Get transfer scope required by Globus Jupyterlab.
+        This should always be globus_sdk.scopes.TransferScopes.all
         """
-        scopes = [TransferScopes.all]
-        custom_transfer_scope = self.get_transfer_submission_scope()
-        if custom_transfer_scope:
-            scopes.append(custom_transfer_scope)
-        return scopes
+        return [self.transfer_scope]
 
     def get_collection_id(self) -> str:
         """

--- a/globus_jupyterlab/tests/api/test_transfer.py
+++ b/globus_jupyterlab/tests/api/test_transfer.py
@@ -168,7 +168,7 @@ def test_401_login_url_with_custom_submission_scope(
         "urn:globus:auth:scope:transfer.api.globus.org:all"
     )
     assert (
-        "http://myscope[https://auth.globus.org/scopes/foo/data_access]"
+        "http://myscope[urn:globus:auth:scope:transfer.api.globus.org:all[https://auth.globus.org/scopes/foo/data_access]"
         in requested_scopes
     )
 


### PR DESCRIPTION
When a custom resource server was configured with a custom scope,
JupyterLab wasn't properly requesting dependent scopes to allow transfers
to take place on the custom collections.

The scopes are now fixed. With the fix applied, users will need to logout
then login again in order for transfers to work properly.

**NOTE** I still need to test this on the hub to make sure it works properly. 